### PR TITLE
README: need `yarn build` before `yarn start:dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,6 @@ $ docker run --rm -p 8080:8080 \
 ```sh
 $ cp public/env/env.js.example public/env/env.js
 $ yarn
+$ yarn build
 $ yarn start:dev
 ```


### PR DESCRIPTION
Directly running `yarn start:dev` fails with errors about missing images and fonts.
After `yarn build` it works (not sure full `build` is necessary for dev mode, maybe something like `yarn copy-fonts` and `yarn copy-images` would suffice, didn't test).