### PR TITLE
Grafana custom dashboard links

### DIFF
--- a/src/pages/ClustersPage.js
+++ b/src/pages/ClustersPage.js
@@ -13,6 +13,7 @@ const GET_CLUSTER = gql`
       name
       description
       serverUrl
+      grafanaUrl
       jumpHost {
         hostname
       }
@@ -38,6 +39,7 @@ const GET_CLUSTERS = gql`
       name
       description
       serverUrl
+      grafanaUrl
       jumpHost {
         hostname
       }

--- a/src/pages/ClustersPage.js
+++ b/src/pages/ClustersPage.js
@@ -21,6 +21,7 @@ const GET_CLUSTER = gql`
         path
         name
         description
+        grafanaUrl
         cluster {
           name
           jumpHost {
@@ -47,6 +48,7 @@ const GET_CLUSTERS = gql`
         path
         name
         description
+        grafanaUrl
         cluster {
           name
           path

--- a/src/pages/NamespacesPage.js
+++ b/src/pages/NamespacesPage.js
@@ -12,6 +12,7 @@ const GET_NAMESPACE = gql`
       path
       name
       description
+      grafanaUrl
       cluster {
         name
         path
@@ -29,6 +30,7 @@ const GET_NAMESPACES = gql`
       path
       name
       description
+      grafanaUrl
       cluster {
         name
         path

--- a/src/pages/elements/Cluster.js
+++ b/src/pages/elements/Cluster.js
@@ -8,7 +8,7 @@ function Cluster({ cluster }) {
   if (cluster.grafanaUrl !== null) {
     grafana = (
       <a href={cluster.grafanaUrl} target="_blank" rel="noopener noreferrer">
-        Grafana
+        Link
       </a>
     );
   } else {

--- a/src/pages/elements/Cluster.js
+++ b/src/pages/elements/Cluster.js
@@ -4,16 +4,7 @@ import Namespaces from './Namespaces';
 import GrafanaUrl from './GrafanaUrl';
 
 function Cluster({ cluster }) {
-  let grafana;
-  if (cluster.grafanaUrl !== null) {
-    grafana = (
-      <a href={cluster.grafanaUrl} target="_blank" rel="noopener noreferrer">
-        Link
-      </a>
-    );
-  } else {
-    grafana = <GrafanaUrl jumpHost={cluster.jumpHost} cluster={cluster.name} />;
-  }
+  const grafana = <GrafanaUrl jumpHost={cluster.jumpHost} cluster={cluster.name} url={cluster.grafanaUrl} />;
   return (
     <React.Fragment>
       <h4>Info</h4>

--- a/src/pages/elements/Cluster.js
+++ b/src/pages/elements/Cluster.js
@@ -4,6 +4,16 @@ import Namespaces from './Namespaces';
 import GrafanaUrl from './GrafanaUrl';
 
 function Cluster({ cluster }) {
+  let grafana;
+  if (cluster.grafanaUrl !== null) {
+    grafana = (
+      <a href={cluster.grafanaUrl} target="_blank" rel="noopener noreferrer">
+        Grafana
+      </a>
+    );
+  } else {
+    grafana = <GrafanaUrl jumpHost={cluster.jumpHost} cluster={cluster.name} />;
+  }
   return (
     <React.Fragment>
       <h4>Info</h4>
@@ -16,7 +26,7 @@ function Cluster({ cluster }) {
               {cluster.path}
             </a>
           ],
-          ['Grafana', <GrafanaUrl jumpHost={cluster.jumpHost} cluster={cluster.name} />]
+          ['Grafana', grafana]
         ]}
       />
 

--- a/src/pages/elements/GrafanaUrl.js
+++ b/src/pages/elements/GrafanaUrl.js
@@ -1,18 +1,22 @@
 import React from 'react';
 
-function GrafanaUrl({ jumpHost, cluster, namespace }) {
+function GrafanaUrl({ jumpHost, cluster, namespace, url }) {
   if (jumpHost !== null) {
     return 'Not available';
   }
-
-  const dataSource = `${cluster}-cluster-prometheus`;
-  let dashboardName = 'k8s-compute-resources-cluster';
-  let additionalVars = '';
-  if (typeof namespace !== 'undefined') {
-    dashboardName = 'k8s-compute-resources-namespace';
-    additionalVars = `&var-namespace=${namespace}`;
+  let grafanaUrl;
+  if (url !== null) {
+    grafanaUrl = url;
+  } else {
+    const dataSource = `${cluster}-cluster-prometheus`;
+    let dashboardName = 'k8s-compute-resources-cluster';
+    let additionalVars = '';
+    if (typeof namespace !== 'undefined') {
+      dashboardName = 'k8s-compute-resources-namespace';
+      additionalVars = `&var-namespace=${namespace}`;
+    }
+    grafanaUrl = `${window.GF_ROOT_URL}/d/${dashboardName}?var-datasource=${dataSource}${additionalVars}`;
   }
-  const grafanaUrl = `${window.GF_ROOT_URL}/d/${dashboardName}?var-datasource=${dataSource}${additionalVars}`;
 
   return (
     <a href={grafanaUrl} target="_blank" rel="noopener noreferrer">

--- a/src/pages/elements/Namespace.js
+++ b/src/pages/elements/Namespace.js
@@ -4,19 +4,14 @@ import GrafanaUrl from './GrafanaUrl';
 import Definition from '../../components/Definition';
 
 function Namespace({ namespace }) {
-  let grafana;
-  if (namespace.grafanaUrl !== null) {
-    grafana = (
-      <a href={namespace.grafanaUrl} target="_blank" rel="noopener noreferrer">
-        Link
-      </a>
-    );
-  } else {
-    grafana = (
-      <GrafanaUrl jumpHost={namespace.cluster.jumpHost} cluster={namespace.cluster.name} namespace={namespace.name} />
-    );
-  }
-  console.log(grafana);
+  const grafana = (
+    <GrafanaUrl
+      jumpHost={namespace.cluster.jumpHost}
+      cluster={namespace.cluster.name}
+      namespace={namespace.name}
+      url={namespace.grafanaUrl}
+    />
+  );
   return (
     <React.Fragment>
       <h4>Info</h4>

--- a/src/pages/elements/Namespace.js
+++ b/src/pages/elements/Namespace.js
@@ -4,6 +4,19 @@ import GrafanaUrl from './GrafanaUrl';
 import Definition from '../../components/Definition';
 
 function Namespace({ namespace }) {
+  let grafana;
+  if (namespace.grafanaUrl !== null) {
+    grafana = (
+      <a href={namespace.grafanaUrl} target="_blank" rel="noopener noreferrer">
+        Grafana
+      </a>
+    );
+  } else {
+    grafana = (
+      <GrafanaUrl jumpHost={namespace.cluster.jumpHost} cluster={namespace.cluster.name} namespace={namespace.name} />
+    );
+  }
+  console.log(grafana);
   return (
     <React.Fragment>
       <h4>Info</h4>
@@ -27,14 +40,7 @@ function Namespace({ namespace }) {
               {namespace.cluster.name}
             </Link>
           ],
-          [
-            'Grafana',
-            <GrafanaUrl
-              jumpHost={namespace.cluster.jumpHost}
-              cluster={namespace.cluster.name}
-              namespace={namespace.name}
-            />
-          ]
+          ['Grafana', grafana]
         ]}
       />
 

--- a/src/pages/elements/Namespace.js
+++ b/src/pages/elements/Namespace.js
@@ -8,7 +8,7 @@ function Namespace({ namespace }) {
   if (namespace.grafanaUrl !== null) {
     grafana = (
       <a href={namespace.grafanaUrl} target="_blank" rel="noopener noreferrer">
-        Grafana
+        Link
       </a>
     );
   } else {

--- a/src/pages/elements/Namespaces.js
+++ b/src/pages/elements/Namespaces.js
@@ -18,9 +18,9 @@ function Namespaces({ namespaces }) {
       ns.cluster_name_path = [ns.cluster.name, ns.cluster.path];
       ns.grafana_url = [ns.cluster.jumpHost, ns.cluster.name, ns.name];
     }
-
     return ns;
   });
+  console.log(processedNamespaces);
 
   const colName = {
     header: {

--- a/src/pages/elements/Namespaces.js
+++ b/src/pages/elements/Namespaces.js
@@ -16,7 +16,16 @@ function Namespaces({ namespaces }) {
     ns.name_path = [ns.name, ns.path];
     if (typeof ns.cluster !== 'undefined') {
       ns.cluster_name_path = [ns.cluster.name, ns.cluster.path];
-      ns.grafana_url = [ns.cluster.jumpHost, ns.cluster.name, ns.name];
+      console.log(ns);
+      if (ns.grafanaUrl !== null) {
+        ns.grafana_url = (
+          <a href={ns.grafanaUrl} target="_blank" rel="noopener noreferrer">
+            Link
+          </a>
+        );
+      } else {
+        ns.grafana_url = <GrafanaUrl jumpHost={ns.cluster.jumpHost} cluster={ns.cluster.name} namespace={ns.name} />;
+      }
     }
     return ns;
   });
@@ -95,7 +104,7 @@ function Namespaces({ namespaces }) {
       formatters: [headerFormat]
     },
     cell: {
-      formatters: [value => <GrafanaUrl jumpHost={value[0]} cluster={value[1]} namespace={value[2]} />, cellFormat]
+      formatters: [cellFormat]
     },
     property: 'grafana_url'
   };

--- a/src/pages/elements/Namespaces.js
+++ b/src/pages/elements/Namespaces.js
@@ -20,8 +20,6 @@ function Namespaces({ namespaces }) {
     }
     return ns;
   });
-  console.log(processedNamespaces);
-
   const colName = {
     header: {
       label: 'Name',

--- a/src/pages/elements/Namespaces.js
+++ b/src/pages/elements/Namespaces.js
@@ -16,16 +16,7 @@ function Namespaces({ namespaces }) {
     ns.name_path = [ns.name, ns.path];
     if (typeof ns.cluster !== 'undefined') {
       ns.cluster_name_path = [ns.cluster.name, ns.cluster.path];
-      console.log(ns);
-      if (ns.grafanaUrl !== null) {
-        ns.grafana_url = (
-          <a href={ns.grafanaUrl} target="_blank" rel="noopener noreferrer">
-            Link
-          </a>
-        );
-      } else {
-        ns.grafana_url = <GrafanaUrl jumpHost={ns.cluster.jumpHost} cluster={ns.cluster.name} namespace={ns.name} />;
-      }
+      ns.grafana_url = [ns.cluster.jumpHost, ns.cluster.name, ns.name, ns.grafanaUrl];
     }
     return ns;
   });
@@ -104,7 +95,10 @@ function Namespaces({ namespaces }) {
       formatters: [headerFormat]
     },
     cell: {
-      formatters: [cellFormat]
+      formatters: [
+        value => <GrafanaUrl jumpHost={value[0]} cluster={value[1]} namespace={value[2]} url={value[3]} />,
+        cellFormat
+      ]
     },
     property: 'grafana_url'
   };


### PR DESCRIPTION
allows service owners to link custom grafana dashboards from cluster/namespace pages. Without showing commits from previous PR (hopefully). 

