### PR TITLE
manage services with children

### DIFF
--- a/src/components/ServicesTable.js
+++ b/src/components/ServicesTable.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Table } from 'patternfly-react';
+import { Link } from 'react-router-dom';
+import { sortByName } from './Utils';
+
+function ServicesTable({ services }) {
+  const headerFormat = value => <Table.Heading>{value}</Table.Heading>;
+  const cellFormat = value => <Table.Cell>{value}</Table.Cell>;
+//   const linkFormat = url => value => <a href={`${url || ''}${value}`}>{value}</a>;
+  // const pathToFormat = url => <Link to={{ pathname: '/services', hash: url }}>{url}</Link>
+//   const pathToFormat = url => url + "1"
+
+  services = sortByName(services.slice()).map(s => {
+    s.name_path = [s.name, s.path];
+    return s;
+  });
+
+  return (
+    <Table.PfProvider
+      striped
+      bordered
+      columns={[
+        {
+          header: {
+            label: 'Name',
+            formatters: [headerFormat]
+          },
+          cell: {
+            formatters: [
+              value => (
+                <Link
+                  to={{
+                    pathname: '/services',
+                    hash: value[1]
+                  }}
+                >
+                  {value[0]}
+                </Link>
+              ),
+              cellFormat
+            ]
+          },
+          property: 'name_path'
+        },
+        {
+          header: {
+            label: 'Description',
+            formatters: [headerFormat]
+          },
+          cell: {
+            formatters: [cellFormat]
+          },
+          property: 'description'
+        },
+      ]}
+    >
+      <Table.Header />
+      <Table.Body rows={sortByName(services)} rowKey="name" />
+    </Table.PfProvider>
+  );
+}
+
+export default ServicesTable;

--- a/src/pages/ServicesPage.js
+++ b/src/pages/ServicesPage.js
@@ -60,6 +60,11 @@ const GET_SERVICE = gql`
           }
         }
       }
+      childrenApps {
+        path
+        name
+        description
+      }
     }
     reports_v1 {
       path
@@ -86,24 +91,8 @@ const GET_SERVICES = gql`
       path
       name
       description
-      performanceParameters {
-        SLO
-      }
-      namespaces {
-        path
+      parentApp {
         name
-        description
-        cluster {
-          name
-          path
-          jumpHost {
-            hostname
-          }
-        }
-        app {
-          name
-          path
-        }
       }
     }
   }
@@ -135,7 +124,9 @@ const ServicesPage = ({ location }) => {
         if (loading) return 'Loading...';
         if (error) return `Error! ${error.message}`;
 
-        const body = <Services services={data.apps_v1} />;
+        const services = data.apps_v1.filter(s => s.parentApp === null);
+
+        const body = <Services services={services} />;
         return <Page title="Services" body={body} />;
       }}
     </Query>

--- a/src/pages/elements/Service.js
+++ b/src/pages/elements/Service.js
@@ -7,6 +7,7 @@ import Namespaces from './Namespaces';
 import Reports from './Reports';
 import Documents from './Documents';
 import GrafanaUrl from './GrafanaUrl';
+import Services from './Services';
 
 function Service({ service, reports, documents }) {
   const headerFormat = value => <Table.Heading>{value}</Table.Heading>;
@@ -177,8 +178,16 @@ function Service({ service, reports, documents }) {
 
       <h4>Info</h4>
       <Definition items={[['SLO', service.performanceParameters.SLO]]} />
-      <h4> Service Owners </h4>
+
+      <h4>Service Owners</h4>
       <Definition items={serviceOwners} />
+
+      {service.childrenApps.length > 0 &&
+        <React.Fragment>
+          <h4>Children Services</h4>
+          <Services services={service.childrenApps} table={true} />
+        </React.Fragment>
+      }
 
       {service.serviceDocs && (
         <React.Fragment>

--- a/src/pages/elements/Services.js
+++ b/src/pages/elements/Services.js
@@ -3,9 +3,10 @@ import { Link } from 'react-router-dom';
 import { chunk } from 'lodash';
 import { Row, Col, Card, CardHeading, CardBody, CardFooter, CardTitle, Label } from 'patternfly-react';
 import { sortByName } from '../../components/Utils';
+import ServicesTable from '../../components/ServicesTable';
 import GridSearch from '../../components/GridSearch';
 
-function Services({ services }) {
+function Services({ services, table }) {
   // cardsWidth * cardsPerRow must be <= 12 (bootstrap grid)
   const cardWidth = 4;
   const cardsPerRow = 3;
@@ -16,6 +17,12 @@ function Services({ services }) {
     return selected === 'Name' && s.name.toLowerCase().includes(lcFilter);
   }
   const matchedServices = services.filter(matches);
+
+
+  if (typeof(table) !== 'undefined' && table) {
+    return <ServicesTable services={matchedServices}/>;
+  }
+
   const rows = chunk(sortByName(matchedServices), cardsPerRow).map(c => (
     <Row key={c[0].path}>
       {c.map(s => (
@@ -24,10 +31,6 @@ function Services({ services }) {
             <CardHeading>
               <CardTitle>
                 {s.name}
-                <span style={{ float: 'right' }}>
-                  <Label bsStyle="primary">SLO</Label>
-                  <Label bsStyle="info">{s.performanceParameters.SLO}</Label>
-                </span>
               </CardTitle>
             </CardHeading>
             <CardBody>{s.description}</CardBody>


### PR DESCRIPTION
- In the top level view of Services, only those without an parent
service are shown.

- Inside each service, there's a new `Children Services` section which
lists all the services that point at that service.

This affects insights.