### PR TITLE
Adding Network CIDRs to Cluster page

### DIFF
--- a/src/pages/ClustersPage.js
+++ b/src/pages/ClustersPage.js
@@ -23,6 +23,11 @@ const GET_CLUSTER = gql`
       jumpHost {
         hostname
       }
+      network {
+        vpc
+        service
+        pod
+      }
       namespaces {
         path
         name

--- a/src/pages/elements/Cluster.js
+++ b/src/pages/elements/Cluster.js
@@ -56,7 +56,10 @@ function Cluster({ cluster, roles }) {
               {cluster.alertmanagerUrl}
             </a>
           ],
-          ['Grafana', grafana]
+          ['Grafana', grafana],
+          ['VPC CIDR', cluster.network.vpc],
+          ['Service CIDR', cluster.network.service],
+          ['Pod CIDR', cluster.network.pod]
         ]}
       />
 


### PR DESCRIPTION
This change is related to https://issues.redhat.com/browse/OSD-4244. Specifically, SREP wants to make sure that there is somewhere other than OCM to quickly find the FQDN and CIDRs for a hive cluster in the event the OCM is down and they need to access one. This adds the three relevant CIDRs to the Clusters page. 