### PR TITLE
Only show network CIDRs for v4 clusters

### DIFF
--- a/src/pages/elements/Cluster.js
+++ b/src/pages/elements/Cluster.js
@@ -57,9 +57,9 @@ function Cluster({ cluster, roles }) {
             </a>
           ],
           ['Grafana', grafana],
-          ['VPC CIDR', cluster.network.vpc],
-          ['Service CIDR', cluster.network.service],
-          ['Pod CIDR', cluster.network.pod]
+          cluster.network !== null && cluster.network.vpc !== null && ['VPC CIDR', cluster.network.vpc],
+          cluster.network !== null && cluster.network.service !== null && ['Service CIDR', cluster.network.service],
+          cluster.network !== null && cluster.network.pod !== null && ['Pod CIDR', cluster.network.pod]
         ]}
       />
 


### PR DESCRIPTION
Following up on #73, this will only show network CIDRs on the Cluster page if the cluster has that information available in app-interface. 