### PR TITLE
add qontract-api url and auth to nginx proxy config

### DIFF
--- a/deployment/entrypoint.sh
+++ b/deployment/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-sed "s|%AUTHORIZATION%|$AUTHORIZATION|;s|%GRAPHQL_URI%|$GRAPHQL_URI|" \
+sed -e "s|%AUTHORIZATION%|$AUTHORIZATION|;s|%GRAPHQL_URI%|$GRAPHQL_URI|" \
+    -e "s|%API_AUTH%|$API_AUTH|;s|%API_URI%|$API_URI|" \
     /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
 exec nginx -g "daemon off;"

--- a/deployment/nginx.conf.template
+++ b/deployment/nginx.conf.template
@@ -31,5 +31,9 @@ http {
             proxy_set_header Authorization "%AUTHORIZATION%";
             proxy_pass %GRAPHQL_URI%;
         }
+        location /api {
+            proxy_set_header Authorization "%API_AUTH%";
+            proxy_pass %API_URI%;
+        }
     }
 }

--- a/openshift/visual-qontract.yaml
+++ b/openshift/visual-qontract.yaml
@@ -44,6 +44,16 @@ objects:
               secretKeyRef:
                   key: authorization
                   name: visual-qontract
+          - name: API_URI
+            valueFrom:
+              configMapKeyRef:
+                key: api.uri
+                name: visual-qontract
+          - name: API_AUTH
+            valueFrom:
+              secretKeyRef:
+                  key: api.auth
+                  name: visual-qontract
           ports:
           - containerPort: 8080
           livenessProbe:


### PR DESCRIPTION
This adds an /api endpoint to the nginx config. That endpoint proxies to the qontract-api service using basic auth. This ensures only visual-app-interface can call qontract-api

This change requires secret and configmap updates which will be made via a MR to app-interface (TBD)