### PR TITLE
pass user headers to nginx, set as cookie

### DIFF
--- a/deployment/nginx.conf.template
+++ b/deployment/nginx.conf.template
@@ -25,6 +25,8 @@ http {
         location / {
             try_files $uri $uri/ /index.html =404;
             add_header Cache-Control "no-cache, no-store, must-revalidate";
+            add_header Set-Cookie "github-oauth-user=$http_x_forwarded_user";
+            add_header Set-Cookie "github-oauth-email=$http_x_forwarded_email";
         }
 
         location /graphql {

--- a/openshift/visual-qontract.yaml
+++ b/openshift/visual-qontract.yaml
@@ -125,6 +125,7 @@ objects:
           - -provider=$(OAUTH2_PROXY_PROVIDER)
           - -github-org=$(OAUTH2_PROXY_GITHUB_ORG)
           - -redirect-url=$(OAUTH2_PROXY_REDIRECT_URL)
+          - -pass-user-headers
           resources:
             requests:
               memory: ${OAUTH_MEMORY_REQUESTS}


### PR DESCRIPTION
This configures the oauth proxy container to send additional headers to the upstream (X-Forwarded-User, X-Forwarded-Email) which will correspond to the user's github username and email

We then set those as a cookie in the headers returned to the client. This will effectively make those readable by javascript so we can do rudimentary (and loose) authorization based on this. 