### PR TITLE
Add ability to authz access to certain URIs to a list of usernames coming from oauth proxy

### DIFF
--- a/deployment/nginx.conf.template
+++ b/deployment/nginx.conf.template
@@ -12,6 +12,8 @@ http {
     include mime.types;
     default_type application/octet-stream;
 
+    include oauth-authz-map.conf;
+
     server {
         listen 8080 default;
         client_max_body_size 1m;
@@ -29,6 +31,14 @@ http {
                 add_header Set-Cookie "github-oauth-user=$http_x_forwarded_user";
                 add_header Set-Cookie "github-oauth-email=$http_x_forwarded_email";
             }
+        }
+
+        location /notifications {
+            if ($authz_notifications !~ 1) {
+                return 401 "You do not have access this function";
+            }
+            try_files $uri $uri/ /index.html =404;
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
         }
 
         location /graphql {

--- a/deployment/nginx.conf.template
+++ b/deployment/nginx.conf.template
@@ -27,10 +27,6 @@ http {
         location / {
             try_files $uri $uri/ /index.html =404;
             add_header Cache-Control "no-cache, no-store, must-revalidate";
-            if ($request_uri ~ "^/$") {
-                add_header Set-Cookie "github-oauth-user=$http_x_forwarded_user";
-                add_header Set-Cookie "github-oauth-email=$http_x_forwarded_email";
-            }
         }
 
         location /notifications {

--- a/deployment/oauth-authz-map.conf.example
+++ b/deployment/oauth-authz-map.conf.example
@@ -1,0 +1,15 @@
+# This map defines mapping of usernames (github usernames) to variables based on the value of X-Forwarded-User header passed from the Oauth proxy
+# By default the value is 0 which prevents access to functionnality.
+# A list of github usernames can be added with a value of '1' to grant access
+# Each list allows us to define URIs that can or cannot be accessed based on map membership and the Oauth authenticated user's username
+map $http_x_forwarded_user $authz_notifications {
+    default 1;
+
+    #userA 1;
+    #userB 1;
+    #...   1;
+}
+
+#map $http_x_forwarded_user $authz_other {
+#    default 0;
+#}

--- a/openshift/visual-qontract.yaml
+++ b/openshift/visual-qontract.yaml
@@ -81,7 +81,7 @@ objects:
             - name: visual-qontract-env
               mountPath: /opt/visual-qontract/build/env/
               readOnly: true
-            - name: oauth-authz-map
+            - name: visual-qontract-oauth-authz-map
               mountPath: /etc/nginx/oauth-authz-map.conf
               subPath: oauth-authz-map.conf
               readOnly: true
@@ -160,7 +160,7 @@ objects:
             items:
             - key: env
               path: env.js
-        - name: oauth-authz-map
+        - name: visual-qontract-oauth-authz-map
           configMap:
             name: visual-qontract-oauth-authz-map
     triggers:

--- a/openshift/visual-qontract.yaml
+++ b/openshift/visual-qontract.yaml
@@ -81,6 +81,10 @@ objects:
             - name: visual-qontract-env
               mountPath: /opt/visual-qontract/build/env/
               readOnly: true
+            - name: oauth-authz-map
+              mountPath: /etc/nginx/oauth-authz-map.conf
+              subPath: oauth-authz-map.conf
+              readOnly: true
         - image: ${IMAGE_OAUTH2_PROXY}:${IMAGE_OAUTH2_PROXY_TAG}
           imagePullPolicy: Always
           name: visual-qontract-oauth2-proxy
@@ -156,6 +160,9 @@ objects:
             items:
             - key: env
               path: env.js
+        - name: oauth-authz-map
+          configMap:
+            name: visual-qontract-oauth-authz-map
     triggers:
     - type: ConfigChange
 - apiVersion: v1


### PR DESCRIPTION
The Oauth proxy sends headers such as `X-Forwarded-User` and `X-Forwarded-Email` in all requests to upstream.

This effectively tells nginx to map the value of `X-Forwarded-User` to a variable (ex: `authz_notifications`, see file `oauth-authz-map.conf.example`). And then in the `location` matching the URIs we want to authorize on, we check what the value of the variable and allow/deny access based on whether the value is `0` or `1`

Contrary to the previous approach based on cookies, this is secure as there is no way for for client to influence the value of the headers sent by the Oauth proxy to the upstream app (nginx).