### PR TITLE
Fix authz nginx config, add 403.html page

### DIFF
--- a/deployment/nginx.conf.template
+++ b/deployment/nginx.conf.template
@@ -24,14 +24,16 @@ http {
         root   /opt/visual-qontract/build;
         index  index.html;
 
+        error_page 403 /403.html;
+
         location /notifications {
-            if ($authz_notifications !~ 1) {
-                return 403 "You do not have access this function";
+            if ($authz_notifications = 0) {
+                return 403;
             }
             try_files $uri $uri/ /index.html =404;
             add_header Cache-Control "no-cache, no-store, must-revalidate";
         }
-        
+
         location / {
             try_files $uri $uri/ /index.html =404;
             add_header Cache-Control "no-cache, no-store, must-revalidate";

--- a/deployment/oauth-authz-map.conf.example
+++ b/deployment/oauth-authz-map.conf.example
@@ -3,7 +3,7 @@
 # A list of github usernames can be added with a value of '1' to grant access
 # Each list allows us to define URIs that can or cannot be accessed based on map membership and the Oauth authenticated user's username
 map $http_x_forwarded_user $authz_notifications {
-    default 1;
+    default 0;
 
     #userA 1;
     #userB 1;

--- a/public/403.html
+++ b/public/403.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>App-Interface</title>
+  </head>
+  <body>
+      <h1>403 - Forbidden</h1>
+      <span>You are not authorized to access this page. Please contact the App-SRE team for help.</span>
+  </body>
+</html>


### PR DESCRIPTION
- `return 403` can technically return a message, but most browser do not like it. This removed the message.
- Adds a custom 403 error page which is served by `try_files` when a 403 is returned instead of returning `index.html` along with the HTTP 403.