### PR TITLE
fix no cluster skip upgrade

### DIFF
--- a/src/pages/elements/ClusterUpgrades.js
+++ b/src/pages/elements/ClusterUpgrades.js
@@ -106,7 +106,11 @@ function ClusterUpgrades({ clusters }) {
   return <React.Fragment>
     <h2>Batch 1</h2><UpgradeBucketTable clusters={clustersByUpgrade['batch1']} />
     <h2>Batch 2</h2><UpgradeBucketTable clusters={clustersByUpgrade['batch2']} />
-    <h2>Skip</h2><UpgradeBucketTable clusters={clustersByUpgrade['skip']} />
+    {clustersByUpgrade['skip'] && 
+        <React.Fragment>
+            <h2>Skip</h2><UpgradeBucketTable clusters={clustersByUpgrade['skip']} />
+        </React.Fragment>
+    }
     </React.Fragment>;
 }
 


### PR DESCRIPTION
Due to https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/9713/diffs
clusterUpgrades page is blank

Signed-off-by: Feng Huang <fehuang@redhat.com>