### PR TITLE
Services: allow listing child apps and show parent apps as labels on cards

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -150,3 +150,19 @@ a:focus {
 .policyList{
   padding: 0px 20px;
 }
+
+.label {
+   margin-left: 20px;
+   padding: 0px 10px 0px 10px;
+
+   border: 2px solid #42a5f5;
+   border-radius: 50px;
+
+   color: white;
+   background-color: #42a5f5;
+
+   font-size: 12px;
+   font-weight: bold;
+
+   float: right;
+ }

--- a/src/components/GridSearch.js
+++ b/src/components/GridSearch.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { CardGrid } from 'patternfly-react';
 import SearchBar from './SearchBar';
 
-function GridSearch({ data, filterText, changeFilterText, changeSelected, selected }) {
+function GridSearch({ data, filterText, changeFilterText, changeSelected, options, selected }) {
   return (
     <React.Fragment>
       <CardGrid matchHeight>
@@ -10,6 +10,7 @@ function GridSearch({ data, filterText, changeFilterText, changeSelected, select
           filterText={filterText}
           handleFilterTextChange={changeFilterText}
           handleSelect={changeSelected}
+          options={options}
           selected={selected}
         />
         {data}

--- a/src/components/Label.js
+++ b/src/components/Label.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function Label({text}) {
+    return (
+        <span class="label">
+        {text}
+        </span>  
+    );
+}
+
+export default Label;

--- a/src/pages/ServicesPage.js
+++ b/src/pages/ServicesPage.js
@@ -93,6 +93,7 @@ const GET_SERVICES = gql`
       description
       parentApp {
         name
+        path
       }
     }
   }
@@ -124,7 +125,7 @@ const ServicesPage = ({ location }) => {
         if (loading) return 'Loading...';
         if (error) return `Error! ${error.message}`;
 
-        const services = data.apps_v1.filter(s => s.parentApp === null);
+        const services = data.apps_v1;
 
         const body = <Services services={services} />;
         return <Page title="Services" body={body} />;

--- a/src/pages/elements/Services.js
+++ b/src/pages/elements/Services.js
@@ -5,19 +5,23 @@ import { Row, Col, Card, CardHeading, CardBody, CardFooter, CardTitle } from 'pa
 import { sortByName } from '../../components/Utils';
 import ServicesTable from '../../components/ServicesTable';
 import GridSearch from '../../components/GridSearch';
+import Label from '../../components/Label';
 
 function Services({ services, table }) {
   // cardsWidth * cardsPerRow must be <= 12 (bootstrap grid)
   const cardWidth = 4;
   const cardsPerRow = 3;
-  const [selected, changeSelected] = useState('Name');
+  const options = ['Show children apps', 'Hide children apps'];
+  const [selected, changeSelected] = useState(options[0]);
   const [filterText, changeFilterText] = useState('');
   const lcFilter = filterText.toLowerCase();
   function matches(s) {
-    return selected === 'Name' && s.name.toLowerCase().includes(lcFilter);
+    return (
+      (selected === options[0] && s.name.toLowerCase().includes(lcFilter)) ||
+      (selected === options[1] && s.name.toLowerCase().includes(lcFilter) && s.parentApp === null)
+    );
   }
   const matchedServices = services.filter(matches);
-
 
   if (typeof(table) !== 'undefined' && table) {
     return <ServicesTable services={matchedServices}/>;
@@ -31,6 +35,15 @@ function Services({ services, table }) {
             <CardHeading>
               <CardTitle>
                 {s.name}
+                {s.parentApp && (
+                  <Link
+                    to={{
+                      pathname: '/services',
+                      hash: s.parentApp['path']
+                    }}>
+                      <Label text={s.parentApp['name']} />
+                  </Link>
+                )}
               </CardTitle>
             </CardHeading>
             <CardBody>{s.description}</CardBody>
@@ -58,6 +71,7 @@ function Services({ services, table }) {
       filterText={filterText}
       changeFilterText={changeFilterText}
       changeSelected={changeSelected}
+      options={options}
       selected={selected}
     />
   );


### PR DESCRIPTION
As a user I should be able to find all services on the services page

This introduces two changes in the Services page
- Options dropdown to allow showing or hiding 'child' apps. All apps are now listed by default
- Child apps are now shown with a label beside the app name that tells what the parent app is. The label is a link to the parent app.

Options dropdown
![2020-12-16-143753_407x148_scrot](https://user-images.githubusercontent.com/3001/102397824-6d8fd680-3fac-11eb-91b9-2803249f181c.png)

Parent app label
![2020-12-16-143645_401x207_scrot](https://user-images.githubusercontent.com/3001/102397843-74b6e480-3fac-11eb-8f28-3181e5dea480.png)
