### PR TITLE
Improve reports page visual design

### DIFF
--- a/src/components/Utils.js
+++ b/src/components/Utils.js
@@ -19,6 +19,15 @@ const sortByLabel = items =>
     if (a.label.toLowerCase() > b.label.toLowerCase()) return 1;
     if (a.label.toLowerCase() < b.label.toLowerCase()) return -1;
     return 0;
-  });
+});
 
-export { sortByName, sortByValue, sortByLabel};
+const sortByDate = items =>
+  items.slice().sort((a, b) => {
+    var dateA = new Date(a.date);
+    var dateB = new Date(b.date);
+    if (dateA > dateB) return -1;
+    if (dateA < dateB) return 1;
+    return 0;
+});
+
+export { sortByName, sortByValue, sortByLabel, sortByDate};

--- a/src/pages/ReportsPage.js
+++ b/src/pages/ReportsPage.js
@@ -24,6 +24,7 @@ const GET_REPORT = gql`
       cluster {
         name
         path
+        consoleUrl
       }
     }
   }

--- a/src/pages/elements/Report.js
+++ b/src/pages/elements/Report.js
@@ -55,7 +55,7 @@ const ReportVulnerabilities = ({ get_ns, vulnerabilities }) => {
         columns={[
           {
             header: {
-              label: 'Cluster/ Namespace',
+              label: 'Cluster / Namespace',
               formatters: [headerFormat]
             },
             cell: {
@@ -234,21 +234,12 @@ const PostDeployJobs = ({ get_ns, post_deploy_jobs}) => {
         columns={[
           {
             header: {
-              label: 'Cluster',
+              label: 'Cluster / Namespace',
               formatters: [headerFormat]
             },
             cell: {
-              formatters: [ns=>(<LinkCluster path={ns.cluster.path} name={ns.cluster.name}/>) , cellFormat]
-            },
-            property: 'ns'
-          },
-          {
-            header: {
-              label: 'Namespace',
-              formatters: [headerFormat]
-            },
-            cell: {
-              formatters: [ns=>(<LinkNS path={ns.path} name={ns.name}/>), cellFormat]
+              formatters: [ns=>(<p>
+              <LinkCluster path={ns.cluster.path} name={ns.cluster.name} /> / <LinkNS path={ns.path} name={ns.name} /></p>) , cellFormat]
             },
             property: 'ns'
           },
@@ -259,6 +250,16 @@ const PostDeployJobs = ({ get_ns, post_deploy_jobs}) => {
             },
             cell: {
               formatters: [ns=>(<GrafanaContainerVulnerabilities namespace={ns} label="Grafana Dashboard" />) , cellFormat]
+            },
+            property: 'ns'
+          },
+          {
+            header: {
+              label: 'Console',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [ns=>(<LinkConsole consoleUrl={ns.cluster.consoleUrl} />) , cellFormat]
             },
             property: 'ns'
           },
@@ -305,21 +306,12 @@ const DeploymentValidations = ({ get_ns, deployment_validations}) => {
         columns={[
           {
             header: {
-              label: 'Cluster',
+              label: 'Cluster / Namespace',
               formatters: [headerFormat]
             },
             cell: {
-              formatters: [ns=>(<LinkCluster path={ns.cluster.path} name={ns.cluster.name}/>), cellFormat]
-            },
-            property: 'ns'
-          },
-          {
-            header: {
-              label: 'Namespace',
-              formatters: [headerFormat]
-            },
-            cell: {
-              formatters: [ns=>(<LinkNS path={ns.path} name={ns.name}/>), cellFormat]
+              formatters: [ns=>(<p>
+              <LinkCluster path={ns.cluster.path} name={ns.cluster.name} /> / <LinkNS path={ns.path} name={ns.name} /></p>) , cellFormat]
             },
             property: 'ns'
           },
@@ -330,6 +322,16 @@ const DeploymentValidations = ({ get_ns, deployment_validations}) => {
             },
             cell: {
               formatters: [ns=>(<GrafanaContainerVulnerabilities namespace={ns} label="Grafana Dashboard" />) , cellFormat]
+            },
+            property: 'ns'
+          },
+          {
+            header: {
+              label: 'Console',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [ns=>(<LinkConsole consoleUrl={ns.cluster.consoleUrl} />) , cellFormat]
             },
             property: 'ns'
           },

--- a/src/pages/elements/Report.js
+++ b/src/pages/elements/Report.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Label, Table } from 'patternfly-react';
+import { Table } from 'patternfly-react';
 import { Link } from 'react-router-dom';
-
+import OnboardingStatus from '../../components/OnboardingStatus';
 import Definition from '../../components/Definition';
 import GrafanaContainerVulnerabilities from '../../components/GrafanaContainerVulnerabilities';
 
@@ -211,7 +211,7 @@ function Report({ report, namespaces }) {
               formatters: [headerFormat]
             },
             cell: {
-              formatters: [booleanFormat(<Label bsStyle="success">Success</Label>, <Label bsStyle="danger">Failure</Label>), cellFormat]
+              formatters: [booleanFormat(<OnboardingStatus state={"Success"}>Success</OnboardingStatus> , <OnboardingStatus state={"Failure"}>Failure</OnboardingStatus>), cellFormat]
             },
             property: 'post_deploy_job'
           }

--- a/src/pages/elements/Report.js
+++ b/src/pages/elements/Report.js
@@ -24,6 +24,13 @@ const LinkCluster = ({ path, name }) =>
 const LinkNS = ({ path, name }) =>
   <Link to={{ 'pathname': '/namespaces', 'hash': path }}>{name}</Link>;
 
+// link to cluster console 
+const LinkConsole = ({ consoleUrl }) => (
+  <a href={`${consoleUrl || ''}/k8s/ns/openshift-customer-monitoring/secscan.quay.redhat.com~v1alpha1~ImageManifestVuln`} target="_blank" rel="noopener noreferrer">
+  Console
+  </a>
+);
+
 // displays the list of vulnerabilities
 const Vulnerabilities = ({vs}) => {
   return <ul>
@@ -64,6 +71,16 @@ const ReportVulnerabilities = ({ get_ns, vulnerabilities }) => {
             },
             cell: {
               formatters: [ns=>(<GrafanaContainerVulnerabilities namespace={ns} label="Grafana Dashboard" />) , cellFormat]
+            },
+            property: 'ns'
+          },
+          {
+            header: {
+              label: 'Console',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [ns=>(<LinkConsole consoleUrl={ns.cluster.consoleUrl} />) , cellFormat]
             },
             property: 'ns'
           },
@@ -371,7 +388,7 @@ const DeploymentValidations = ({ get_ns, deployment_validations}) => {
   </React.Fragment>
 }
 
-function Report({ report, namespaces }) {
+function Report({ report, namespaces}) {
   const content = yaml.safeLoad(report.content);
 
   // fetch the namespace. Returns `undefined` if not found
@@ -381,7 +398,7 @@ function Report({ report, namespaces }) {
   if (content.valet == null) {
     valetTable = <p style={{ 'font-style': 'italic' }}>No valet.</p>;
   }
-  
+
   // const report_content_dump = yaml.safeDump(content);
 
   return (

--- a/src/pages/elements/Report.js
+++ b/src/pages/elements/Report.js
@@ -93,22 +93,6 @@ const ReportVulnerabilities = ({ get_ns, vulnerabilities }) => {
   return <React.Fragment>
     <h4>Vulnerabilities</h4>
     {reportVulnerabilitiesTable}
-    {/* <ul>
-      {vulnerabilities.map(e => {
-        const ns = get_ns(e["cluster"], e["namespace"])
-        if (typeof (ns) === 'undefined') {
-          return <li key={e["cluster"] + e["namespace"]}>
-            {e["cluster"]} / {e["namespace"]}: <Vulnerabilities vs={e['vulnerabilities']} />
-          </li>
-        } else {
-          return <li key={e["cluster"] + e["namespace"]}>
-            <LinkCluster path={ns.cluster.path} name={ns.cluster.name} /> / <LinkNS path={ns.path} name={ns.name} /> (
-              <GrafanaContainerVulnerabilities namespace={ns} label="Grafana Dashboard" />
-            ): <Vulnerabilities vs={e['vulnerabilities']} />
-          </li>
-        }
-      })}
-    </ul> */}
   </React.Fragment>
 }
 

--- a/src/pages/elements/Report.js
+++ b/src/pages/elements/Report.js
@@ -356,7 +356,7 @@ function Report({ report, namespaces }) {
   const vulns = content['container_vulnerabilities'];
   delete content.container_vulnerabilities;
 
-  const report_content_dump = yaml.safeDump(content);
+  // const report_content_dump = yaml.safeDump(content);
 
   return (
     <React.Fragment>
@@ -391,7 +391,7 @@ function Report({ report, namespaces }) {
       {<MergesToMaster content={content}/>}
       {<PostDeployJobs content={content} get_ns={get_ns} />}
       {<DeploymentValidations content={content} get_ns={get_ns}/>}
-      <pre>{report_content_dump}</pre>
+      {/* <pre>{report_content_dump}</pre> */}
     </React.Fragment>
   );
 }

--- a/src/pages/elements/Report.js
+++ b/src/pages/elements/Report.js
@@ -57,36 +57,23 @@ function Report({ report, namespaces }) {
       {value}
     </a>
   );
-  const emptyFormat = value => value || '-';
   const booleanFormat = (t, f) => value => (value ? t : f);
 
   const content = yaml.safeLoad(report.content);
-  console.log(content.merges_to_master);
-  //console.log(content.deployment_validations[0].validations.deployment_validation_operator_replica_validation.Failed);
 
-  function flatten(obj, suffix, ans) {
-    for (var x in obj) {
-        var key;
-        if (suffix != '')
-          key = suffix + '.' + x;
-        else
-          key = x;
-      if (typeof obj[x] === 'object') {
-        flatten(obj[x], key, ans);
-      } else {
-        ans[key] = obj[x];
-      }
-    }
-  }
-
-  if (content.deployment_validation) {
+  if (content.deployment_validations) {
     var deployment_validations_flattened = [];
     var i = 0;
-    for (var validation of content.deployment_validations) {
-      var validation_flattened = {};
-      flatten(validation, "", validation_flattened);
+    var validation_flattened;
+    for (var deployment of content.deployment_validations) {
+      validation_flattened = {};
+      validation_flattened['cluster'] = deployment.cluster
+      validation_flattened['namespace'] = deployment.namespace
+      validation_flattened['validations.deployment_validation_operator_request_limit_validation.Passed'] = deployment.validations.deployment_validation_operator_request_limit_validation.Passed
+      validation_flattened['validations.deployment_validation_operator_replica_validation.Failed'] = deployment.validations.deployment_validation_operator_replica_validation.Failed
+
       deployment_validations_flattened[i] = validation_flattened;
-      i += 1
+      i += 1;
     }
   }
 

--- a/src/pages/elements/Report.js
+++ b/src/pages/elements/Report.js
@@ -34,9 +34,66 @@ const Vulnerabilities = ({vs}) => {
 // displays the vulnerabilities section
 const ReportVulnerabilities = ({ get_ns, vulnerabilities }) => {
 
+  let reportVulnerabilitiesTable;
+  if (vulnerabilities == null) {
+    reportVulnerabilitiesTable = <p style={{ 'font-style': 'italic' }}>No vulnerabilities.</p>;
+  } else {
+    var new_vulnerabilities = [];
+    var new_job;
+    for (const [i, vulnerability] of vulnerabilities.entries()) {
+      new_job = {};
+      new_job['ns'] = get_ns(vulnerability['cluster'], vulnerability['namespace']);
+      new_job['vulnerabilities'] = vulnerability['vulnerabilities'];
+      new_vulnerabilities[i] = new_job;
+    }
+    reportVulnerabilitiesTable = (
+      <Table.PfProvider
+        striped
+        bordered
+        columns={[
+          {
+            header: {
+              label: 'Cluster/ Namespace',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [ns=>(<p>
+              <LinkCluster path={ns.cluster.path} name={ns.cluster.name} /> / <LinkNS path={ns.path} name={ns.name} /></p>) , cellFormat]
+            },
+            property: 'ns'
+          },
+          {
+            header: {
+              label: 'Grafana',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [ns=>(<GrafanaContainerVulnerabilities namespace={ns} label="Grafana Dashboard" />) , cellFormat]
+            },
+            property: 'ns'
+          },
+          {
+            header: {
+              label: 'Vulnerabilities',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [vulnerabilities=><Vulnerabilities vs={vulnerabilities} />, cellFormat]
+            },
+            property: 'vulnerabilities'
+          }
+        ]}
+      >
+        <Table.Header />
+        <Table.Body rows={new_vulnerabilities} rowKey="cluster" />
+      </Table.PfProvider>
+    );
+  }
+
   return <React.Fragment>
     <h4>Vulnerabilities</h4>
-    <ul>
+    {reportVulnerabilitiesTable}
+    {/* <ul>
       {vulnerabilities.map(e => {
         const ns = get_ns(e["cluster"], e["namespace"])
         if (typeof (ns) === 'undefined') {
@@ -51,7 +108,7 @@ const ReportVulnerabilities = ({ get_ns, vulnerabilities }) => {
           </li>
         }
       })}
-    </ul>
+    </ul> */}
   </React.Fragment>
 }
 

--- a/src/pages/elements/Report.js
+++ b/src/pages/elements/Report.js
@@ -370,8 +370,6 @@ function Report({ report, namespaces }) {
       {<ProductionPromotions content={content}/>}
       {<MergesToMaster content={content}/>}
       {<PostDeployJobs content={content} get_ns={get_ns} />}
-      {/* <h4>Deployment Validation</h4>
-      {deploymentValidationTable} */}
       {<DeploymentValidations content={content} get_ns={get_ns}/>}
       <pre>{report_content_dump}</pre>
     </React.Fragment>

--- a/src/pages/elements/Report.js
+++ b/src/pages/elements/Report.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Label, Table } from 'patternfly-react';
 import { Link } from 'react-router-dom';
 
 import Definition from '../../components/Definition';
@@ -49,7 +50,248 @@ const ReportVulnerabilities = ({ namespaces, vulnerabilities }) => {
 }
 
 function Report({ report, namespaces }) {
+  const headerFormat = value => <Table.Heading>{value}</Table.Heading>;
+  const cellFormat = value => <Table.Cell>{value}</Table.Cell>;
+  const linkFormat = url => value => (
+    <a href={`${url || ''}${value}`} target="_blank" rel="noopener noreferrer">
+      {value}
+    </a>
+  );
+  const emptyFormat = value => value || '-';
+  const booleanFormat = (t, f) => value => (value ? t : f);
+
   const content = yaml.safeLoad(report.content);
+  console.log(content.merges_to_master);
+  //console.log(content.deployment_validations[0].validations.deployment_validation_operator_replica_validation.Failed);
+
+  function flatten(obj, suffix, ans) {
+    for (var x in obj) {
+        var key;
+        if (suffix != '')
+          key = suffix + '.' + x;
+        else
+          key = x;
+      if (typeof obj[x] === 'object') {
+        flatten(obj[x], key, ans);
+      } else {
+        ans[key] = obj[x];
+      }
+    }
+  }
+
+  if (content.deployment_validation) {
+    var deployment_validations_flattened = [];
+    var i = 0;
+    for (var validation of content.deployment_validations) {
+      var validation_flattened = {};
+      flatten(validation, "", validation_flattened);
+      deployment_validations_flattened[i] = validation_flattened;
+      i += 1
+    }
+  }
+
+  let valetTable;
+  if (content.valet == null) {
+    valetTable = <p style={{ 'font-style': 'italic' }}>No valet.</p>;
+  }
+
+  let productionPromotionsTable;
+  if (content.production_promotions == null) {
+    productionPromotionsTable = <p style={{ 'font-style': 'italic' }}>No production_promotions.</p>;
+  } else {
+    productionPromotionsTable = (
+      <Table.PfProvider
+        striped
+        bordered
+        columns={[
+          {
+            header: {
+              label: 'Repo',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [linkFormat(), cellFormat]
+            },
+            property: 'repo'
+          },
+          {
+            header: {
+              label: 'Total',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [cellFormat]
+            },
+            property: 'total'
+          },
+          {
+            header: {
+              label: 'Success',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [cellFormat]
+            },
+            property: 'success'
+          }
+        ]}
+      >
+        <Table.Header />
+        <Table.Body rows={content.production_promotions} rowKey="repo" />
+      </Table.PfProvider>
+    );
+  }
+
+  let mergesToMasterTable;
+  if (content.merges_to_master == null) {
+    mergesToMasterTable = <p style={{ 'font-style': 'italic' }}>No merges_to_master.</p>;
+  } else {
+    mergesToMasterTable = (
+      <Table.PfProvider
+        striped
+        bordered
+        columns={[
+          {
+            header: {
+              label: 'Repo',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [linkFormat(), cellFormat]
+            },
+            property: 'repo'
+          },
+          {
+            header: {
+              label: 'Total',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [cellFormat]
+            },
+            property: 'total'
+          },
+          {
+            header: {
+              label: 'Success',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [cellFormat]
+            },
+            property: 'success'
+          }
+        ]}
+      >
+        <Table.Header />
+        <Table.Body rows={content.merges_to_master} rowKey="repo" />
+      </Table.PfProvider>
+    );
+  }
+
+  let postDeployJobsTable;
+  if (content.post_deploy_jobs == null) {
+    postDeployJobsTable = <p style={{ 'font-style': 'italic' }}>No post_deploy_jobs.</p>;
+  } else {
+    postDeployJobsTable = (
+      <Table.PfProvider
+        striped
+        bordered
+        columns={[
+          {
+            header: {
+              label: 'Cluster',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [linkFormat(), cellFormat]
+            },
+            property: 'cluster'
+          },
+          {
+            header: {
+              label: 'Namespace',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [linkFormat(), cellFormat]
+            },
+            property: 'namespace'
+          },
+          {
+            header: {
+              label: 'Post Deploy Job',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [booleanFormat(<Label bsStyle="success">Success</Label>, <Label bsStyle="danger">Failure</Label>), cellFormat]
+            },
+            property: 'post_deploy_job'
+          }
+        ]}
+      >
+        <Table.Header />
+        <Table.Body rows={content.post_deploy_jobs} rowKey="cluster" />
+      </Table.PfProvider>
+    );
+  }
+
+  let deploymentValidationTable;
+  if (content.deployment_validations == null) {
+    deploymentValidationTable = <p style={{ 'font-style': 'italic' }}>No deployment_validations.</p>;
+  } else {
+    deploymentValidationTable = (
+      <Table.PfProvider
+        striped
+        bordered
+        columns={[
+          {
+            header: {
+              label: 'Cluster',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [linkFormat(), cellFormat]
+            },
+            property: 'cluster'
+          },
+          {
+            header: {
+              label: 'Namespace',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [linkFormat(), cellFormat]
+            },
+            property: 'namespace'
+          },
+          {
+            header: {
+              label: 'Request Limit Validation',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [cellFormat]
+            },
+            property: 'validations.deployment_validation_operator_request_limit_validation.Passed'
+          },
+          {
+            header: {
+              label: 'Replica Validation',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [cellFormat]
+            },
+            property: 'validations.deployment_validation_operator_replica_validation.Failed'
+          }
+        ]}
+      >
+        <Table.Header />
+        <Table.Body rows={deployment_validations_flattened} rowKey="cluster" />
+      </Table.PfProvider>
+    );
+  }
 
   const vulns = content['container_vulnerabilities'];
   delete content.container_vulnerabilities;
@@ -83,7 +325,16 @@ function Report({ report, namespaces }) {
         ]}
       />
       {vulns && <ReportVulnerabilities namespaces={namespaces} vulnerabilities={vulns} />}
-      <h4>Content</h4>
+      <h4>Valet</h4>
+      {valetTable}
+      <h4>Production Promotions</h4>
+      {productionPromotionsTable}
+      <h4>Merges To Master</h4>
+      {mergesToMasterTable}
+      <h4>Post-deploy Jobs</h4>
+      {postDeployJobsTable}
+      <h4>Deployment Validation</h4>
+      {deploymentValidationTable}
       <pre>{report_content_dump}</pre>
     </React.Fragment>
   );

--- a/src/pages/elements/Report.js
+++ b/src/pages/elements/Report.js
@@ -38,13 +38,8 @@ const ReportVulnerabilities = ({ get_ns, vulnerabilities }) => {
   if (vulnerabilities == null) {
     reportVulnerabilitiesTable = <p style={{ 'font-style': 'italic' }}>No vulnerabilities.</p>;
   } else {
-    var new_vulnerabilities = [];
-    var new_job;
-    for (const [i, vulnerability] of vulnerabilities.entries()) {
-      new_job = {};
-      new_job['ns'] = get_ns(vulnerability['cluster'], vulnerability['namespace']);
-      new_job['vulnerabilities'] = vulnerability['vulnerabilities'];
-      new_vulnerabilities[i] = new_job;
+    for (var i = 0; i < vulnerabilities.length; i++) {
+      vulnerabilities[i]['ns'] = get_ns(vulnerabilities[i]['cluster'], vulnerabilities[i]['namespace']);
     }
     reportVulnerabilitiesTable = (
       <Table.PfProvider
@@ -85,7 +80,7 @@ const ReportVulnerabilities = ({ get_ns, vulnerabilities }) => {
         ]}
       >
         <Table.Header />
-        <Table.Body rows={new_vulnerabilities} rowKey="cluster" />
+        <Table.Body rows={vulnerabilities} rowKey="cluster" />
       </Table.PfProvider>
     );
   }
@@ -97,9 +92,9 @@ const ReportVulnerabilities = ({ get_ns, vulnerabilities }) => {
 }
 
 // displays the productionPromotions Table
-const ProductionPromotions = ({content}) => {
+const ProductionPromotions = ({production_promotions}) => {
   let productionPromotionsTable;
-  if (content.production_promotions == null) {
+  if (production_promotions == null) {
     productionPromotionsTable = <p style={{ 'font-style': 'italic' }}>No production_promotions.</p>;
   } else {
     productionPromotionsTable = (
@@ -140,7 +135,7 @@ const ProductionPromotions = ({content}) => {
         ]}
       >
         <Table.Header />
-        <Table.Body rows={content.production_promotions} rowKey="repo" />
+        <Table.Body rows={production_promotions} rowKey="repo" />
       </Table.PfProvider>
     );
   }
@@ -152,9 +147,9 @@ const ProductionPromotions = ({content}) => {
 }
 
 // displays the MergesToMaster Table
-const MergesToMaster = ({content}) => {
+const MergesToMaster = ({merges_to_master}) => {
   let mergesToMasterTable;
-  if (content.merges_to_master == null) {
+  if (merges_to_master == null) {
     mergesToMasterTable = <p style={{ 'font-style': 'italic' }}>No merges_to_master.</p>;
   } else {
     mergesToMasterTable = (
@@ -195,7 +190,7 @@ const MergesToMaster = ({content}) => {
         ]}
       >
         <Table.Header />
-        <Table.Body rows={content.merges_to_master} rowKey="repo" />
+        <Table.Body rows={merges_to_master} rowKey="repo" />
       </Table.PfProvider>
     );
   }
@@ -207,18 +202,13 @@ const MergesToMaster = ({content}) => {
 }
 
 // displays the PostDeployJobs Table
-const PostDeployJobs = ({ get_ns, content}) => {
+const PostDeployJobs = ({ get_ns, post_deploy_jobs}) => {
   let postDeployJobsTable;
-  if (content.post_deploy_jobs == null) {
+  if (post_deploy_jobs == null) {
     postDeployJobsTable = <p style={{ 'font-style': 'italic' }}>No post_deploy_jobs.</p>;
   } else {
-    var post_deploy_jobs = [];
-    var new_job;
-    for (const [i, job] of content.post_deploy_jobs.entries()) {
-      new_job = {};
-      new_job['ns'] = get_ns(job['cluster'], job['namespace']);
-      new_job['post_deploy_job'] = job['post_deploy_job'];
-      post_deploy_jobs[i] = new_job;
+    for (var i = 0; i < post_deploy_jobs.length; i++) {
+      post_deploy_jobs[i]['ns'] = get_ns(post_deploy_jobs[i]['cluster'], post_deploy_jobs[i]['namespace']);
     }
     postDeployJobsTable = (
       <Table.PfProvider
@@ -281,22 +271,16 @@ const PostDeployJobs = ({ get_ns, content}) => {
 }
 
 // displays the DeploymentValidations Table
-const DeploymentValidations = ({ get_ns, content}) => {
-  if (content.deployment_validations) {
-    var deployment_validations_flattened = [];
-    var validation;
-    for (const [i, deployment] of content.deployment_validations.entries()) {
-      validation= {};
-      validation['ns'] = get_ns(deployment.cluster, deployment.namespace);
-      validation['validations'] = deployment.validations;
-      deployment_validations_flattened[i] = validation;
-    }
-  }
+const DeploymentValidations = ({ get_ns, deployment_validations}) => {
 
   let deploymentValidationTable;
-  if (content.deployment_validations == null) {
+  if (deployment_validations == null) {
     deploymentValidationTable = <p style={{ 'font-style': 'italic' }}>No deployment_validations.</p>;
   } else {
+    for (var i = 0; i < deployment_validations.length; i++) {
+      deployment_validations[i]['ns'] = get_ns(deployment_validations[i].cluster, deployment_validations[i].namespace);
+    }
+ 
     deploymentValidationTable = (
       <Table.PfProvider
         striped
@@ -376,7 +360,7 @@ const DeploymentValidations = ({ get_ns, content}) => {
       >
     
         <Table.Header />
-        <Table.Body rows={deployment_validations_flattened} />
+        <Table.Body rows={deployment_validations} />
       </Table.PfProvider>
     );
   }
@@ -397,10 +381,7 @@ function Report({ report, namespaces }) {
   if (content.valet == null) {
     valetTable = <p style={{ 'font-style': 'italic' }}>No valet.</p>;
   }
-
-  const vulns = content['container_vulnerabilities'];
-  delete content.container_vulnerabilities;
-
+  
   // const report_content_dump = yaml.safeDump(content);
 
   return (
@@ -429,13 +410,13 @@ function Report({ report, namespaces }) {
           ['Date', report.date]
         ]}
       />
-      {vulns && <ReportVulnerabilities vulnerabilities={vulns} get_ns={get_ns}/>}
+      {<ReportVulnerabilities vulnerabilities={content.container_vulnerabilities} get_ns={get_ns}/>}
       <h4>Valet</h4>
       {valetTable}
-      {<ProductionPromotions content={content}/>}
-      {<MergesToMaster content={content}/>}
-      {<PostDeployJobs content={content} get_ns={get_ns} />}
-      {<DeploymentValidations content={content} get_ns={get_ns}/>}
+      {<ProductionPromotions production_promotions={content.production_promotions}/>}
+      {<MergesToMaster merges_to_master={content.merges_to_master}/>}
+      {<PostDeployJobs post_deploy_jobs={content.post_deploy_jobs} get_ns={get_ns} />}
+      {<DeploymentValidations deployment_validations={content.deployment_validations} get_ns={get_ns}/>}
       {/* <pre>{report_content_dump}</pre> */}
     </React.Fragment>
   );

--- a/src/pages/elements/Report.js
+++ b/src/pages/elements/Report.js
@@ -203,6 +203,16 @@ const PostDeployJobs = ({ get_ns, content}) => {
           },
           {
             header: {
+              label: 'Grafana',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [ns=>(<GrafanaContainerVulnerabilities namespace={ns} label="Grafana Dashboard" />) , cellFormat]
+            },
+            property: 'ns'
+          },
+          {
+            header: {
               label: 'Post Deploy Job',
               formatters: [headerFormat]
             },
@@ -264,6 +274,16 @@ const DeploymentValidations = ({ get_ns, content}) => {
             },
             cell: {
               formatters: [ns=>(<LinkNS path={ns.path} name={ns.name}/>), cellFormat]
+            },
+            property: 'ns'
+          },
+          {
+            header: {
+              label: 'Grafana',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [ns=>(<GrafanaContainerVulnerabilities namespace={ns} label="Grafana Dashboard" />) , cellFormat]
             },
             property: 'ns'
           },

--- a/src/pages/elements/Report.js
+++ b/src/pages/elements/Report.js
@@ -327,16 +327,6 @@ const DeploymentValidations = ({ get_ns, deployment_validations}) => {
           },
           {
             header: {
-              label: 'Console',
-              formatters: [headerFormat]
-            },
-            cell: {
-              formatters: [ns=>(<LinkConsole consoleUrl={ns.cluster.consoleUrl} />) , cellFormat]
-            },
-            property: 'ns'
-          },
-          {
-            header: {
               label: 'Request Limit Validation Passed',
               formatters: [headerFormat]
             },
@@ -396,13 +386,6 @@ function Report({ report, namespaces}) {
   // fetch the namespace. Returns `undefined` if not found
   const get_ns = (c, ns) => namespaces.filter(n => n['name'] === ns && n['cluster']['name'] === c)[0];
 
-  let valetTable;
-  if (content.valet == null) {
-    valetTable = <p style={{ 'font-style': 'italic' }}>No valet.</p>;
-  }
-
-  // const report_content_dump = yaml.safeDump(content);
-
   return (
     <React.Fragment>
       <h4>Info</h4>
@@ -430,13 +413,10 @@ function Report({ report, namespaces}) {
         ]}
       />
       {<ReportVulnerabilities vulnerabilities={content.container_vulnerabilities} get_ns={get_ns}/>}
-      <h4>Valet</h4>
-      {valetTable}
       {<ProductionPromotions production_promotions={content.production_promotions}/>}
       {<MergesToMaster merges_to_master={content.merges_to_master}/>}
       {<PostDeployJobs post_deploy_jobs={content.post_deploy_jobs} get_ns={get_ns} />}
       {<DeploymentValidations deployment_validations={content.deployment_validations} get_ns={get_ns}/>}
-      {/* <pre>{report_content_dump}</pre> */}
     </React.Fragment>
   );
 }

--- a/src/pages/elements/Report.js
+++ b/src/pages/elements/Report.js
@@ -55,6 +55,7 @@ const ReportVulnerabilities = ({ get_ns, vulnerabilities }) => {
   </React.Fragment>
 }
 
+// displays the productionPromotions Table
 const ProductionPromotions = ({content}) => {
   let productionPromotionsTable;
   if (content.production_promotions == null) {
@@ -109,6 +110,7 @@ const ProductionPromotions = ({content}) => {
   </React.Fragment>
 }
 
+// displays the MergesToMaster Table
 const MergesToMaster = ({content}) => {
   let mergesToMasterTable;
   if (content.merges_to_master == null) {
@@ -163,6 +165,7 @@ const MergesToMaster = ({content}) => {
   </React.Fragment>
 }
 
+// displays the PostDeployJobs Table
 const PostDeployJobs = ({ get_ns, content}) => {
   let postDeployJobsTable;
   if (content.post_deploy_jobs == null) {
@@ -236,6 +239,7 @@ const PostDeployJobs = ({ get_ns, content}) => {
   </React.Fragment>
 }
 
+// displays the DeploymentValidations Table
 const DeploymentValidations = ({ get_ns, content}) => {
   if (content.deployment_validations) {
     var deployment_validations_flattened = [];

--- a/src/pages/elements/Reports.js
+++ b/src/pages/elements/Reports.js
@@ -4,7 +4,7 @@ import { Table } from 'patternfly-react';
 import { sortByName, sortByDate } from '../../components/Utils';
 import TableSearch from '../../components/TableSearch';
 
-function Reports({ reports, latest=false }) {
+function Reports({ reports }) {
   const headerFormat = value => <Table.Heading>{value}</Table.Heading>;
   const cellFormat = value => <Table.Cell>{value}</Table.Cell>;
   const options = ['Name', 'App'];
@@ -96,30 +96,18 @@ function Reports({ reports, latest=false }) {
     }
   ];
 
-  if (latest) {
-    return (
-      <Table.PfProvider
-        striped
-        bordered
-        columns={columns}
-      >
-        <Table.Header />
-        <Table.Body rows={[matchedReports[0]]}/>
-      </Table.PfProvider>
-    )
-  } else {
-    return (
-      <TableSearch
-        filterText={filterText}
-        changeFilterText={changeFilterText}
-        changeSelected={changeSelected}
-        options={options}
-        selected={selected}
-        columns={columns}
-        rows={matchedReports}
-      />
-    );
-  }
+  
+  return (
+    <TableSearch
+      filterText={filterText}
+      changeFilterText={changeFilterText}
+      changeSelected={changeSelected}
+      options={options}
+      selected={selected}
+      columns={columns}
+      rows={matchedReports}
+    />
+  );
 }
 
 export default Reports;

--- a/src/pages/elements/Reports.js
+++ b/src/pages/elements/Reports.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Table } from 'patternfly-react';
-import { sortByName } from '../../components/Utils';
+import { sortByName, sortByDate } from '../../components/Utils';
 import TableSearch from '../../components/TableSearch';
 
 function Reports({ reports }) {
@@ -16,7 +16,7 @@ function Reports({ reports }) {
     </a>
   );
 
-  const processedReports = sortByName(reports).map(r => {
+  const processedReports = sortByDate(sortByName(reports)).map(r => {
     r.name_path = [r.name, r.path];
     return r;
   });

--- a/src/pages/elements/Reports.js
+++ b/src/pages/elements/Reports.js
@@ -4,7 +4,7 @@ import { Table } from 'patternfly-react';
 import { sortByName, sortByDate } from '../../components/Utils';
 import TableSearch from '../../components/TableSearch';
 
-function Reports({ reports }) {
+function Reports({ reports, latest=false }) {
   const headerFormat = value => <Table.Heading>{value}</Table.Heading>;
   const cellFormat = value => <Table.Cell>{value}</Table.Cell>;
   const options = ['Name', 'App'];
@@ -96,17 +96,30 @@ function Reports({ reports }) {
     }
   ];
 
-  return (
-    <TableSearch
-      filterText={filterText}
-      changeFilterText={changeFilterText}
-      changeSelected={changeSelected}
-      options={options}
-      selected={selected}
-      columns={columns}
-      rows={matchedReports}
-    />
-  );
+  if (latest) {
+    return (
+      <Table.PfProvider
+        striped
+        bordered
+        columns={columns}
+      >
+        <Table.Header />
+        <Table.Body rows={[matchedReports[0]]}/>
+      </Table.PfProvider>
+    )
+  } else {
+    return (
+      <TableSearch
+        filterText={filterText}
+        changeFilterText={changeFilterText}
+        changeSelected={changeSelected}
+        options={options}
+        selected={selected}
+        columns={columns}
+        rows={matchedReports}
+      />
+    );
+  }
 }
 
 export default Reports;

--- a/src/pages/elements/Service.js
+++ b/src/pages/elements/Service.js
@@ -226,13 +226,19 @@ function Service({ service, reports, documents }) {
 
       <h4>Quay Repos</h4>
       {quayReposTable}
-
+    
       {matchedReports.length > 0 && (
         <React.Fragment>
           <h4>Reports</h4>
+          <Reports reports={matchedReports} latest={true} />
+          <details>
+          <summary>More reports</summary>
+          <br></br>
           <Reports reports={matchedReports} />
+          </details>
         </React.Fragment>
       )}
+
       {matchedDocuments.length > 0 && (
         <React.Fragment>
           <h4>Documents</h4>

--- a/src/pages/elements/Service.js
+++ b/src/pages/elements/Service.js
@@ -169,7 +169,7 @@ function Service({ service, reports, documents }) {
     ]
   ]);
 
-  // list only lastest report
+  // list only latest report
   let latestReport;
   if (matchedReports != null) {
     latestReport = [matchedReports[0]].map(r => [

--- a/src/pages/elements/Service.js
+++ b/src/pages/elements/Service.js
@@ -3,7 +3,7 @@ import { Label, Table } from 'patternfly-react';
 import Definition from '../../components/Definition';
 import CodeComponents from '../../components/ServiceCodeComponents';
 import EndPoints from '../../components/ServiceEndPoints';
-import sortByDate from '../../components/Utils';
+import { sortByDate } from '../../components/Utils';
 import Namespaces from './Namespaces';
 import Reports from './Reports';
 import Documents from './Documents';

--- a/src/pages/elements/Service.js
+++ b/src/pages/elements/Service.js
@@ -3,6 +3,7 @@ import { Label, Table } from 'patternfly-react';
 import Definition from '../../components/Definition';
 import CodeComponents from '../../components/ServiceCodeComponents';
 import EndPoints from '../../components/ServiceEndPoints';
+import sortByDate from '../../components/Utils';
 import Namespaces from './Namespaces';
 import Reports from './Reports';
 import Documents from './Documents';
@@ -26,7 +27,7 @@ function Service({ service, reports, documents }) {
     }
     return false;
   }
-  const matchedReports = reports.filter(matches);
+  const matchedReports = sortByDate(reports).filter(matches);
   const matchedDocuments = documents.filter(matches);
 
   let quayReposTable;

--- a/src/pages/elements/Service.js
+++ b/src/pages/elements/Service.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Label, Table } from 'patternfly-react';
+import { Link } from 'react-router-dom';
 import Definition from '../../components/Definition';
 import CodeComponents from '../../components/ServiceCodeComponents';
 import EndPoints from '../../components/ServiceEndPoints';
@@ -167,6 +168,26 @@ function Service({ service, reports, documents }) {
       '>'
     ]
   ]);
+
+  // list only lastest report
+  let latestReport;
+  if (matchedReports != null) {
+    latestReport = [matchedReports[0]].map(r => [
+      [
+        r.name, 
+        ': ',
+        <Link
+          to={{
+              pathname: '/reports',
+              hash: r.path
+              }}
+        >
+          {r.path}
+        </Link>
+      ]
+    ]);
+  }
+  
   return (
     <React.Fragment>
       <h4>Description</h4>
@@ -183,6 +204,17 @@ function Service({ service, reports, documents }) {
 
       <h4>Service Owners</h4>
       <Definition items={serviceOwners} />
+
+      {matchedReports &&
+        <div>      
+          <h4>Reports</h4>
+          <Definition items={latestReport} />
+          <details>
+              <summary>More reports</summary>
+              <br></br>
+              <Reports reports={matchedReports} />
+          </details>
+        </div>}
 
       {service.childrenApps.length > 0 &&
         <React.Fragment>
@@ -226,18 +258,6 @@ function Service({ service, reports, documents }) {
 
       <h4>Quay Repos</h4>
       {quayReposTable}
-    
-      {matchedReports.length > 0 && (
-        <React.Fragment>
-          <h4>Reports</h4>
-          <Reports reports={matchedReports} latest={true} />
-          <details>
-          <summary>More reports</summary>
-          <br></br>
-          <Reports reports={matchedReports} />
-          </details>
-        </React.Fragment>
-      )}
 
       {matchedDocuments.length > 0 && (
         <React.Fragment>


### PR DESCRIPTION
-  Add tables for vulnerabilities, deployment validations, post deploy jobs, merges to master, production promotions
-  Add links to cluster/namespace definitions
-  Add links to Grafana dashboards
-  For reports page, sort reports by date, then by name
-  For service page, sort reports by date
-  For service page, add "details" button to expand more reports
-  Add openshift console links to report page  