### PR TITLE
readiness probe for graphql endpoint

### DIFF
--- a/openshift/visual-qontract.yaml
+++ b/openshift/visual-qontract.yaml
@@ -64,12 +64,9 @@ objects:
             periodSeconds: 10
             timeoutSeconds: 3
           readinessProbe:
-            exec:
-              command:
-              - curl
-              - --globoff
-              - --fail
-              - http://localhost:8080/graphql?query={__schema{types{name}}}
+            httpGet:
+              path: /graphql?query={__schema{types{name}}}
+              port: 8080
             initialDelaySeconds: 3
             periodSeconds: 10
             timeoutSeconds: 3

--- a/openshift/visual-qontract.yaml
+++ b/openshift/visual-qontract.yaml
@@ -64,9 +64,12 @@ objects:
             periodSeconds: 10
             timeoutSeconds: 3
           readinessProbe:
-            httpGet:
-              path: /
-              port: 8080
+            exec:
+              command:
+              - curl
+              - --globoff
+              - --fail
+              - http://localhost:8080/graphql?query={__schema{types{name}}}
             initialDelaySeconds: 3
             periodSeconds: 10
             timeoutSeconds: 3


### PR DESCRIPTION
we are experiencing a failure in visual-qontract from time to time, with a pod restart solving things.
the output on the screen is usually:
```
Error! Network error: Unexpected token < in JSON at position 0
```

looked at the logs while this was happening and saw the following:
```
POST /graphql HTTP/1.1" 404
```
went to the browser and navigated to the base url with /graphql and indeed got a 404.

this PR is intended to cause a restart that should get us out of the situation.