### PR TITLE
liveness probe for graphql endpoint

### DIFF
--- a/openshift/visual-qontract.yaml
+++ b/openshift/visual-qontract.yaml
@@ -58,7 +58,7 @@ objects:
           - containerPort: 8080
           livenessProbe:
             httpGet:
-              path: /
+              path: /graphql?query={__schema{types{name}}}
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 10


### PR DESCRIPTION
follows up on #119

this will cause the container to actually restart.