### PR TITLE
all cluster upgrades are now manual

### DIFF
--- a/src/pages/ClusterUpgradesPage.js
+++ b/src/pages/ClusterUpgradesPage.js
@@ -18,7 +18,6 @@ const GET_CLUSTERS = gql`
         external_id
       }
       upgradePolicy {
-        schedule_type
         schedule
       }
     }

--- a/src/pages/ClustersPage.js
+++ b/src/pages/ClustersPage.js
@@ -86,7 +86,6 @@ const GET_CLUSTERS = gql`
         external_id
       }
       upgradePolicy {
-        schedule_type
         schedule
       }
     }

--- a/src/pages/elements/Clusters.js
+++ b/src/pages/elements/Clusters.js
@@ -181,7 +181,7 @@ function Clusters({ clusters, apps }) {
     }
 
     if (c.upgradePolicy) {
-      c.upgrade_schedule = `${c.upgradePolicy.schedule_type} - ${c.upgradePolicy.schedule}`;
+      c.upgrade_schedule = `${c.upgradePolicy.schedule}`;
     }
 
     return c;


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3640

we are no longer using `schedule_type`.