### PR TITLE
[Service Page] add trigger tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
     "react-router-dom": "^5.0.0",
     "react-scripts": ">=2.0.0",
     "react-select": "^3.1.0",
+    "react-tooltip": "^4.2.21",
     "recompose": "^0.30.0",
+    "sass": "^1.32.8",
     "sortabular": "^1.6.0",
-    "table-resolver": "^4.1.1",
-    "sass": "^1.32.8"
+    "table-resolver": "^4.1.1"
   },
   "devDependencies": {
     "eslint-config-airbnb": "^17.1.0",

--- a/src/pages/elements/Service.js
+++ b/src/pages/elements/Service.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactTooltip from 'react-tooltip';
 import { Label, Table } from 'patternfly-react';
 import { Link } from 'react-router-dom';
 import Definition from '../../components/Definition';
@@ -104,9 +105,10 @@ const PipelineRuns = ({saas_file, settings}) => {
       long_name = saas_file.name + '-' + target.namespace.environment.name
       short_name = long_name.substring(0, 50); // max name length can be 63. leaving 12 for the timestamp - 51
       url = pp_cluster_console_url + '/k8s/ns/' + pp_ns_name + '/tekton.dev~v1beta1~Pipeline/' + pipeline_name + '/Runs?name=' + short_name;
+      var tooltip = 'to trigger a deployment, click Actions -> Start. details:' + '<br />' + 'saas_file_name: ' + saas_file.name + '<br />' + 'env_name: ' + target.namespace.environment.name + '<br />' + 'tkn_cluster_console_url: ' + pp_cluster_console_url + '<br />' + 'tkn_namespace_name: ' + pp_ns_name
       if (!urls.includes(url)) {
         urls.push(url)
-        elem = <li><a href={url} target="_blank"> {target.namespace.environment.name} </a></li>
+        elem = <li><a href={url} target="_blank" data-tip={tooltip}> {target.namespace.environment.name} </a><ReactTooltip multiline={true} clickable={true} /></li>
         url_elements.push(elem);
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10406,6 +10406,14 @@ react-select@^3.1.0:
     react-input-autosize "^2.2.2"
     react-transition-group "^4.3.0"
 
+react-tooltip@^4.2.21:
+  version "4.2.21"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.21.tgz#840123ed86cf33d50ddde8ec8813b2960bfded7f"
+  integrity sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==
+  dependencies:
+    prop-types "^15.7.2"
+    uuid "^7.0.3"
+
 react-transition-group@^2.0.0, react-transition-group@^2.2.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
@@ -12321,6 +12329,11 @@ uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
It's currently not trivial to trigger deployments using tekton. with this PR, we now have a copyable tooltip from which we can copy the information needed to trigger a deployment of a saas file to a selected environment (the link takes us to the pipelines page where we trigger).
![image](https://user-images.githubusercontent.com/28562329/133830404-6b6837f2-e71b-423b-9ce3-8eba16fe6887.png)
