### PR TITLE
add console namespace link to namespace page

### DIFF
--- a/src/pages/elements/Namespace.js
+++ b/src/pages/elements/Namespace.js
@@ -67,14 +67,20 @@ function Namespace({ namespace, roles }) {
           ],
           [
             'Cluster',
-            <Link
-              to={{
-                pathname: '/clusters',
-                hash: namespace.cluster.path
-              }}
-            >
-              {namespace.cluster.name}
-            </Link>
+            <>
+              <Link
+                to={{
+                  pathname: '/clusters',
+                  hash: namespace.cluster.path
+                }}
+              >
+                {namespace.cluster.name}
+              </Link>
+              &nbsp;&nbsp;
+              <a href={namespace.cluster.consoleUrl + "/k8s/cluster/projects/" + namespace.name} target="_blank">
+                <i className="fa fa-desktop" />
+              </a>
+            </>
           ],
           [
             'App',


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3788

this will add a small desktop icon (like we already have in the Clusters page) to allow a link from a Namespace page directly to the cluster's console directly into the namespace.