### PR TITLE
[WIP] Include slo-doc-names in slo table on Report page

### DIFF
--- a/src/pages/elements/Report.js
+++ b/src/pages/elements/Report.js
@@ -648,19 +648,19 @@ const DeploymentValidations = ({ get_ns, deployment_validations }) => {
   );
 };
 
-const add_to_slo = ({ get_ns, slo, slo_doc_for_report }) => {
-  slo.ns = get_ns(slo.cluster, slo.namespace);
-  slo.grafana = slo_doc_for_report.slos.filter(slo => slo.name === slo.slo_name)[0].dashboard;
-  const { slo_value, slo_target } = slo;
+const add_to_slo = ({ get_ns, slo: service_slo, slo_doc }) => {
+  service_slo.ns = get_ns(service_slo.cluster, service_slo.namespace);
+  service_slo.grafana = slo_doc.slos.filter(slo => slo.name === service_slo.slo_name)[0].dashboard;
+  const { slo_value, slo_target } = service_slo;
   if (slo_value >= slo_target) {
-    slo.slo_pair = (
+    service_slo.slo_pair = (
       <span style={{ backgroundColor: 'green' }} className="badge Pass">
         {' '}
         {slo_value} / {slo_target}
       </span>
     );
   } else {
-    slo.slo_pair = (
+    service_slo.slo_pair = (
       <span style={{ backgroundColor: 'red' }} className="badge Fail">
         {' '}
         {slo_value} / {slo_target}
@@ -676,8 +676,8 @@ const ServiceSLO = ({ get_ns, service_slo, slo_documents_for_report }) => {
     ServiceSLOTable = <p style={{ 'font-style': 'italic' }}>No service_slo.</p>;
   } else {
     for (let i = 0; i < service_slo.length; i++) {
-      slo_doc_for_report = slo_documents_for_report.filter(doc => doc.name === service_slo[i].slo_doc_name)[0]
-      add_to_slo(get_ns, service_slo[i], slo_doc_for_report)
+      slo_doc = slo_documents_for_report.filter(doc => doc.name === service_slo[i].slo_doc_name)[0]
+      add_to_slo(get_ns, service_slo[i], slo_doc)
     }
     ServiceSLOTable = (
       <Table.PfProvider

--- a/src/pages/elements/Report.js
+++ b/src/pages/elements/Report.js
@@ -699,6 +699,16 @@ const ServiceSLO = ({ get_ns, service_slo, slo_document }) => {
           },
           {
             header: {
+              label: 'SLO Doc',
+              formatters: [headerFormat]
+            },
+            cell: {
+              formatters: [cellFormat]
+            },
+            property: 'slo_doc'
+          },
+          {
+            header: {
               label: 'SLO Name',
               formatters: [headerFormat]
             },


### PR DESCRIPTION
This implements the 'Implementation - Producing Service Reports' portion of [this design doc](https://github.com/app-sre/qontract-reconcile/blob/master/docs/design/slo_doc_tracking_for_slo_metric_data.md) and relates to [this internal Jira issue](https://issues.redhat.com/browse/APPSRE-3570).

---

This PR updates the Report view page's SLO table to include a `SLO Doc` column.

---

This PR will break visual-qontract report pages if merged before [this](https://github.com/app-sre/dashdotdb/pull/62), [this](https://github.com/app-sre/qontract-reconcile/pull/1931), [this](https://github.com/app-sre/qontract-reconcile/pull/1932), and before letting the dashdotdb-slo Q-R integration run at least once.