### PR TITLE
Convert DeploymentConfig to Deployment

### DIFF
--- a/openshift/visual-qontract.yaml
+++ b/openshift/visual-qontract.yaml
@@ -4,8 +4,8 @@ kind: Template
 metadata:
   name: visual-qontract
 objects:
-- apiVersion: v1
-  kind: DeploymentConfig
+- apiVersion: apps/v1
+  kind: Deployment
   metadata:
     labels:
       app: visual-qontract
@@ -13,21 +13,19 @@ objects:
   spec:
     replicas: 1
     selector:
-      app: visual-qontract
-      deploymentconfig: visual-qontract
+      matchLabels:
+        app: visual-qontract
+        deployment: visual-qontract
     strategy:
-      rollingParams:
-        intervalSeconds: 1
+      rollingUpdate:
         maxSurge: 25%
         maxUnavailable: 25%
-        timeoutSeconds: 600
-        updatePeriodSeconds: 1
-      type: Rolling
+      type: RollingUpdate
     template:
       metadata:
         labels:
           app: visual-qontract
-          deploymentconfig: visual-qontract
+          deployment: visual-qontract
       spec:
         containers:
         - image: ${IMAGE}:${IMAGE_TAG}
@@ -172,7 +170,7 @@ objects:
         targetPort: 4180
         protocol: TCP
     selector:
-      deploymentconfig: visual-qontract
+      deployment: visual-qontract
 - apiVersion: v1
   kind: Service
   metadata:
@@ -187,7 +185,7 @@ objects:
         targetPort: 8080
         protocol: TCP
     selector:
-      deploymentconfig: visual-qontract
+      deployment: visual-qontract
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/visual-qontract

--- a/openshift/visual-qontract.yaml
+++ b/openshift/visual-qontract.yaml
@@ -4,6 +4,160 @@ kind: Template
 metadata:
   name: visual-qontract
 objects:
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: visual-qontract
+    name: visual-qontract
+  spec:
+    replicas: 1
+    selector:
+      app: visual-qontract
+      deployment: visual-qontract
+    strategy:
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: visual-qontract
+          deployment: visual-qontract
+      spec:
+        containers:
+        - image: ${IMAGE}:${IMAGE_TAG}
+          imagePullPolicy: Always
+          name: visual-qontract
+          env:
+          - name: GRAPHQL_URI
+            valueFrom:
+              configMapKeyRef:
+                key: graphql.uri
+                name: visual-qontract
+          - name: AUTHORIZATION
+            valueFrom:
+              secretKeyRef:
+                  key: authorization
+                  name: visual-qontract
+          - name: API_URI
+            valueFrom:
+              configMapKeyRef:
+                key: api.uri
+                name: visual-qontract
+          - name: API_AUTH
+            valueFrom:
+              secretKeyRef:
+                  key: api.auth
+                  name: visual-qontract
+          ports:
+          - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /graphql?query={__schema{types{name}}}
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /graphql?query={__schema{types{name}}}
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+          resources:
+            requests:
+              memory: ${MEMORY_REQUESTS}
+              cpu: ${CPU_REQUESTS}
+            limits:
+              memory: ${MEMORY_LIMIT}
+              cpu: ${CPU_LIMIT}
+          volumeMounts:
+            - name: visual-qontract-env
+              mountPath: /opt/visual-qontract/build/env/
+              readOnly: true
+        - image: ${IMAGE_OAUTH2_PROXY}:${IMAGE_OAUTH2_PROXY_TAG}
+          imagePullPolicy: Always
+          name: visual-qontract-oauth2-proxy
+          env:
+          - name: OAUTH2_PROXY_PROVIDER
+            valueFrom:
+              configMapKeyRef:
+                key: oauth2.proxy.provider
+                name: oauth2-proxy
+          - name: OAUTH2_PROXY_GITHUB_ORG
+            valueFrom:
+              configMapKeyRef:
+                key: oauth2.proxy.github.org
+                name: oauth2-proxy
+          - name: OAUTH2_PROXY_REDIRECT_URL
+            valueFrom:
+              configMapKeyRef:
+                key: oauth2.proxy.redirect.url
+                name: oauth2-proxy
+          - name: OAUTH2_PROXY_COOKIE_SECRET
+            valueFrom:
+              secretKeyRef:
+                  key: oauth2.proxy.cookie.secret
+                  name: oauth2-proxy
+          - name: OAUTH2_PROXY_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                  key: oauth2.proxy.client.id
+                  name: oauth2-proxy
+          - name: OAUTH2_PROXY_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                  key: oauth2.proxy.client.secret
+                  name: oauth2-proxy
+          args:
+          - -http-address=0.0.0.0:4180
+          - -email-domain=*
+          - -upstream=http://localhost:8080
+          - -cookie-secret=$(OAUTH2_PROXY_COOKIE_SECRET)
+          - -client-id=$(OAUTH2_PROXY_CLIENT_ID)
+          - -client-secret=$(OAUTH2_PROXY_CLIENT_SECRET)
+          - -provider=$(OAUTH2_PROXY_PROVIDER)
+          - -github-org=$(OAUTH2_PROXY_GITHUB_ORG)
+          - -redirect-url=$(OAUTH2_PROXY_REDIRECT_URL)
+          - -pass-user-headers
+          resources:
+            requests:
+              memory: ${OAUTH_MEMORY_REQUESTS}
+              cpu: ${OAUTH_CPU_REQUESTS}
+            limits:
+              memory: ${OAUTH_MEMORY_LIMIT}
+              cpu: ${OAUTH_CPU_LIMIT}
+          ports:
+          - containerPort: 4180
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: 4180
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 4180
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+        volumes:
+        - name: visual-qontract-env
+          configMap:
+            name: visual-qontract
+            items:
+            - key: env
+              path: env.js
+    triggers:
+    - type: ConfigChange
 - apiVersion: apps/v1
   kind: Deployment
   metadata:

--- a/openshift/visual-qontract.yaml
+++ b/openshift/visual-qontract.yaml
@@ -154,8 +154,6 @@ objects:
             items:
             - key: env
               path: env.js
-    triggers:
-    - type: ConfigChange
 - apiVersion: v1
   kind: Service
   metadata:


### PR DESCRIPTION
Part of: https://issues.redhat.com/browse/APPSRE-5934

Changes OpenShift template for Visual Qontract to use a DeploymentConfig instead. This means that we lose some of the granularity in our RollingUpdate strategy but gain availability advantages.