### PR TITLE
Optionally Remove Nginx Proxy Server

### DIFF
--- a/deployment/entrypoint.sh
+++ b/deployment/entrypoint.sh
@@ -4,4 +4,15 @@ sed -e "s|%AUTHORIZATION%|$AUTHORIZATION|;s|%GRAPHQL_URI%|$GRAPHQL_URI|" \
     -e "s|%API_AUTH%|$API_AUTH|;s|%API_URI%|$API_URI|" \
     /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
+if [ "$API_URI" = "disable-qontract-api" ]
+then
+    # Option to remove the proxy server setup for Nginx.
+    # This has the side effect that API calls for creating
+    # Slack notifications in the app will result in frontend errors
+    # and is a quick way to get Visual Qontract working in
+    # environments without Slack access
+    sed "34,37d" /etc/nginx/nginx.conf > /tmp/nginx.conf
+    cat /tmp/nginx.conf > /etc/nginx/nginx.conf
+fi
+
 exec nginx -g "daemon off;"


### PR DESCRIPTION
[APPSRE-4277](https://issues.redhat.com/browse/APPSRE-4277)

For FedRamp, we don't have Slack access as it is out of boundary. Therefore, we don't want to deploy [Qontract API](https://gitlab.cee.redhat.com/service/qontract-api) and just deploy Visual Qontract/App Interface by itself. This MR enables us to disable the proxy server by setting the env variable `API_URI=disable-qontract-api`. Otherwise, the proxy server will be created as normal.

My plan of attack following this change is:
1. New container will deploy to staging and I'll monitor logs to ensure it deploys correctly
2. Deploy to App Interface prod
3. Deploy to FR AI

Validated locally w/ local qontract server instance
```
visual-qontract git:entrypoint-update ❯ docker run --rm -p 8080:8080 \                                                                                   ✹
    -e AUTHORIZATION="Basic <TOKEN>" -e GRAPHQL_URI="http://localhost:4000/graphql" \
    -v $PWD/public/env:/opt/visual-qontract/build/env:z \
    -e API_URI=disable-qontract-api -e API_AUTH=test quay.io/app-sre/visual-qontract:latest 
2022/07/29 19:38:36 [notice] 1#1: using the "epoll" event method
2022/07/29 19:38:36 [notice] 1#1: nginx/1.20.1
2022/07/29 19:38:36 [notice] 1#1: built by gcc 4.8.5 20150623 (Red Hat 4.8.5-44) (GCC) 
2022/07/29 19:38:36 [notice] 1#1: OS: Linux 5.18.13-100.fc35.x86_64
2022/07/29 19:38:36 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1073741816:1073741816
2022/07/29 19:38:36 [notice] 1#1: start worker processes
2022/07/29 19:38:36 [notice] 1#1: start worker process 10
172.17.0.1 - - [29/Jul/2022:19:39:04 +0000] "GET / HTTP/1.1" 200 2197 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.134 Safari/537.36 Edg/103.0.1264.77"
```