### PR TITLE
update the nginx stream.  Default 1.14.1 is EOL next month

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY deployment/entrypoint.sh /
 ADD . /opt/visual-qontract
 
 RUN dnf -y update-minimal --security --sec-severity=Important --sec-severity=Critical && \
+    dnf module enable nginx:1.20 -y && \
     dnf install -y nginx && \
     dnf clean all
 


### PR DESCRIPTION
Version in RHEL8 is EOL nov 22.  Enabling the 1.20 stream will give this image the same version used in the centos image.