### PR TITLE
Fix error when saas target has no namespace

### DIFF
--- a/src/pages/elements/Service.js
+++ b/src/pages/elements/Service.js
@@ -84,7 +84,7 @@ const PipelineRuns = ({ saas_file, settings }) => {
   let url;
   let elem;
   for (const template of saas_file.resourceTemplates) {
-    for (const target of template.targets) {
+    for (const target of template.targets.filter(t => t.namespace)) {
       long_name = `${saas_file.name}-${target.namespace.environment.name}`;
       short_name = long_name.substring(0, 50); // max name length can be 63. leaving 12 for the timestamp - 51
       url = `${pp_cluster_console_url}/k8s/ns/${pp_ns_name}/tekton.dev~v1beta1~Pipeline/${pipeline_name}/Runs?name=${short_name}`;
@@ -97,7 +97,7 @@ const PipelineRuns = ({ saas_file, settings }) => {
       if (!urls.includes(url)) {
         urls.push(url);
         elem = (
-          <li>
+          <li key={url}>
             <a href={url} target="_blank" rel="noopener noreferrer" data-tip={tooltip}>
               {' '}
               {target.namespace.environment.name}{' '}


### PR DESCRIPTION
When saas file is using dynamic namespace selector, service page won't render.

```yaml
    provider: dynamic
```

This change check `namespace` exist and fixes a warning about unique key in list.