### PR TITLE
fix typo in scorecard link from service page

### DIFF
--- a/src/pages/elements/Service.js
+++ b/src/pages/elements/Service.js
@@ -365,7 +365,7 @@ function Service({ service, reports, saas_files_v2, scorecards }) {
   if (matchedScorecards.length > 0) {
     const scorecard = matchedScorecards[0];
     const scorecardLink = (
-      <Link to={{ pathname: '/scorecard', hash: scorecard.path }}>Scorecard for {service.name}</Link>
+      <Link to={{ pathname: '/scorecards', hash: scorecard.path }}>Scorecard for {service.name}</Link>
     );
     scorecardSection = scorecardLink;
   } else {


### PR DESCRIPTION
the scorecard link in the service page is incorrect. 
example 
`https://visual-app-interface.devshift.net/scorecard#/services/acs-fleet-manager/scorecard.yml` -> page not found

the proper url should be 
https://visual-app-interface.devshift.net/scorecards#/services/acs-fleet-manager/scorecard.yml