### PR TITLE
support optional cluster.kibanaUrl

### DIFF
--- a/src/pages/elements/Cluster.js
+++ b/src/pages/elements/Cluster.js
@@ -38,7 +38,7 @@ function Cluster({ cluster, roles }) {
               {cluster.consoleUrl}
             </a>
           ],
-          [
+          cluster.kibanaUrl !== null && [
             'Kibana',
             <a href={`${cluster.kibanaUrl}`} target="_blank" rel="noopener noreferrer">
               {cluster.kibanaUrl}


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-8663

following up on https://github.com/app-sre/qontract-schemas/pull/561

with this PR, kibana url will only be shown if the field is not null