### PR TITLE
local instance should use local qontract-server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ Dockerfile.tester
 node_modules
 public/env/env.js
 .docker
+

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,8 @@ test: build-test
 	@docker run --rm $(IMAGE_TEST)
 
 dev-docker-run: build
-	docker run --rm -p 8080:8080 -e AUTHORIZATION=blub -e API_AUTH=blub -e API_URI=https://app-interface.devshift.net -e GRAPHQL_URI=https://app-interface.devshift.net -v $(shell pwd)/public/env:/opt/visual-qontract/build/env $(IMAGE_NAME):latest
+	docker run --rm -p 8080:8080 \
+		-e API_URI=https://host.docker.internal \
+		-e GRAPHQL_URI=https://host.docker.internal \
+		-v $(shell pwd)/public/env:/opt/visual-qontract/build/env \
+		$(IMAGE_NAME):latest


### PR DESCRIPTION
$TITLE

It is more practical for development purposes for the local development instance to use qontract-server instance started locally