### PR TITLE
fix: NewNotifications element doesn't handle dependencies when null

### DIFF
--- a/src/pages/elements/NewNotification.js
+++ b/src/pages/elements/NewNotification.js
@@ -89,6 +89,7 @@ client
   })
   .then(result => {
     for (const service of result.data.apps_v1) {
+      const service_dependencies = service.dependencies != null ? service.dependencies : [];
       const service_owners = service.serviceOwners;
       const service_notificators = service.serviceNotifications;
       const recipients = new Set();
@@ -103,7 +104,7 @@ client
         }
       }
       service_dic[service.name] = recipients;
-      for (const dependency of service.dependencies) {
+      for (const dependency of service_dependencies) {
         if (dependency_dic.hasOwnProperty(dependency.name)) {
           dependency_dic[dependency.name].push(service.name);
         } else {


### PR DESCRIPTION
App_v1 dependencies field is not required and can be null and that causes an exception on all pages

```
Uncaught (in promise) TypeError: e is null
    un NotificationSelect.js:85
    505 NewNotification.js:106
NotificationSelect.js:85:18
    f NotificationSelect.js:85
    505 NewNotification.js:113
```