### PR TITLE
APPSRE-11618: Update cluster page to include "product" and "hypershift" parameters

### DIFF
--- a/src/pages/ClustersPage.js
+++ b/src/pages/ClustersPage.js
@@ -12,8 +12,10 @@ const GET_CLUSTER = gql`
       path
       name
       spec {
+        product
         version
         channel
+        hypershift
       }
       description
       consoleUrl

--- a/src/pages/elements/Cluster.js
+++ b/src/pages/elements/Cluster.js
@@ -32,6 +32,8 @@ function Cluster({ cluster, roles }) {
               {cluster.path}
             </a>
           ],
+          cluster.spec !== null && cluster.spec.product !== null && ['Product', cluster.spec.product],
+          (cluster.spec !== null && cluster.spec.hypershift !== null && ['Hypershift', String(cluster.spec.hypershift)]) || ['Hypershift', String(false)],
           [
             'Console',
             <a href={`${cluster.consoleUrl}`} target="_blank" rel="noopener noreferrer">

--- a/src/pages/elements/Cluster.js
+++ b/src/pages/elements/Cluster.js
@@ -33,7 +33,9 @@ function Cluster({ cluster, roles }) {
             </a>
           ],
           cluster.spec !== null && cluster.spec.product !== null && ['Product', cluster.spec.product],
-          (cluster.spec !== null && cluster.spec.hypershift !== null && ['Hypershift', String(cluster.spec.hypershift)]) || ['Hypershift', String(false)],
+          (cluster.spec !== null && cluster.spec.hypershift !== null &&
+                                    ['Hypershift', String(cluster.spec.hypershift)]) ||
+                                    ['Hypershift', String(false)],
           [
             'Console',
             <a href={`${cluster.consoleUrl}`} target="_blank" rel="noopener noreferrer">

--- a/src/pages/elements/Cluster.js
+++ b/src/pages/elements/Cluster.js
@@ -33,9 +33,11 @@ function Cluster({ cluster, roles }) {
             </a>
           ],
           cluster.spec !== null && cluster.spec.product !== null && ['Product', cluster.spec.product],
-          (cluster.spec !== null && cluster.spec.hypershift !== null &&
-                                    ['Hypershift', String(cluster.spec.hypershift)]) ||
-                                    ['Hypershift', String(false)],
+          (cluster.spec !== null &&
+            cluster.spec.hypershift !== null && ['Hypershift', String(cluster.spec.hypershift)]) || [
+            'Hypershift',
+            String(false)
+          ],
           [
             'Console',
             <a href={`${cluster.consoleUrl}`} target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
[APPSRE-11618](https://issues.redhat.com/browse/APPSRE-11618): Update visual-app-interface cluster page to include  `product` and `hypershift` parameters from App-Interface cluster spec files.

`ClusterPage.js` GQL query modified to fetch `product` and `hypershift` parameters.

`Cluster.js` modified to include `product` and `hypershift` on cluster page.
**Note:** If the `hypershift` parameter is null or undefined we assume it is false.