### PR TITLE
APPSRE-11618: adding hypershift property to main Clusters page.

### DIFF
--- a/src/pages/ClustersPage.js
+++ b/src/pages/ClustersPage.js
@@ -94,6 +94,7 @@ const GET_CLUSTERS = gql`
         channel
         id
         external_id
+        hypershift
       }
       upgradePolicy {
         schedule

--- a/src/pages/elements/Clusters.js
+++ b/src/pages/elements/Clusters.js
@@ -86,6 +86,16 @@ function AppSREClustersTable({ clusters, apps }) {
         },
         {
           header: {
+            label: 'Hypershift',
+            formatters: [headerFormat]
+          },
+          cell: {
+            formatters: [cellFormat]
+          },
+          property: 'hypershift'
+        },
+        {
+          header: {
             label: 'Channel',
             formatters: [headerFormat]
           },
@@ -205,6 +215,7 @@ function Clusters({ clusters, apps }) {
       c.channel = c.spec.channel;
       c.id = c.spec.id;
       c.external_id = c.spec.external_id;
+      c.hypershift = String(c.spec.hypershift === true);
     }
 
     c.upgrade_workloads = [];


### PR DESCRIPTION
`ClusterPage.js` GQL query modified to fetch `hypershift` property for the Clusters page.

`Clusters.js` modified to include `hypershift` in the header def.
**Note:** If the `hypershift` property is null or undefined we assume it is false.

APPSRE-11618