### PR TITLE
APPSRE-10853: add service owner filter dropdown to Services page

### DIFF
--- a/src/pages/elements/Services.js
+++ b/src/pages/elements/Services.js
@@ -6,7 +6,7 @@ import { sortByName } from '../../components/Utils';
 import OnboardingStatus from '../../components/OnboardingStatus';
 
 function collectServiceOwnerNames(services) {
-  const names     = services.flatMap(s => (s.serviceOwners || []).map(o => o?.name).filter(Boolean));
+  const names = services.flatMap(s => (s.serviceOwners || []).map(o => o && o.name).filter(Boolean));
   const uniqNames = new Map(names.map(n => [n.toLowerCase(), n]));
   return Array.from(uniqNames.values()).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
 }

--- a/src/pages/elements/Services.js
+++ b/src/pages/elements/Services.js
@@ -1,15 +1,29 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Table } from 'patternfly-react';
 import { Link } from 'react-router-dom';
+import { Form, FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core';
 import { sortByName } from '../../components/Utils';
 import OnboardingStatus from '../../components/OnboardingStatus';
 
-function Services({ services, omitParentApp }) {
+function collectServiceOwnerNames(services) {
+  const seen = new Map();
+  services.forEach(s =>
+    (s.serviceOwners || []).forEach(o => {
+      if (o && o.name) {
+        const key = o.name.toLowerCase();
+        if (!seen.has(key)) seen.set(key, o.name);
+      }
+    })
+  );
+  return Array.from(seen.values()).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+}
+
+function ServicesTable({ services, omitParentApp }) {
   const headerFormat = value => <Table.Heading>{value}</Table.Heading>;
   const cellFormat = value => <Table.Cell>{value}</Table.Cell>;
   const onboardingStatusFormat = value => <OnboardingStatus state={value} />;
 
-  services = sortByName(services.slice()).map(s => {
+  const rows = sortByName(services.slice()).map(s => {
     s.name_path = [s.name, s.path];
     if (s.parentApp) {
       s.parentAppLink = <Link to={{ pathname: '/services', hash: s.parentApp.path }}>{s.parentApp.name}</Link>;
@@ -98,8 +112,40 @@ function Services({ services, omitParentApp }) {
   return (
     <Table.PfProvider striped bordered columns={columns}>
       <Table.Header />
-      <Table.Body rows={sortByName(services)} rowKey="name" />
+      <Table.Body rows={sortByName(rows)} rowKey="name" />
     </Table.PfProvider>
+  );
+}
+
+function Services({ services, omitParentApp }) {
+  const ownerNames = collectServiceOwnerNames(services);
+  const [selectedOwner, setSelectedOwner] = useState('');
+
+  const filteredServices = selectedOwner
+    ? services.filter(s =>
+        (s.serviceOwners || []).some(o => o && o.name && o.name.toLowerCase() === selectedOwner.toLowerCase())
+      )
+    : services;
+
+  return (
+    <React.Fragment>
+      <Form isHorizontal style={{ maxWidth: '400px', marginBottom: '20px' }}>
+        <FormGroup label="Service owner" fieldId="service-owner-select">
+          <FormSelect
+            id="service-owner-select"
+            value={selectedOwner}
+            onChange={value => setSelectedOwner(value)}
+            aria-label="Filter services by owner"
+          >
+            <FormSelectOption value="" label="All services" />
+            {ownerNames.map(name => (
+              <FormSelectOption key={name} value={name} label={name} />
+            ))}
+          </FormSelect>
+        </FormGroup>
+      </Form>
+      <ServicesTable services={filteredServices} omitParentApp={omitParentApp} />
+    </React.Fragment>
   );
 }
 

--- a/src/pages/elements/Services.js
+++ b/src/pages/elements/Services.js
@@ -6,16 +6,9 @@ import { sortByName } from '../../components/Utils';
 import OnboardingStatus from '../../components/OnboardingStatus';
 
 function collectServiceOwnerNames(services) {
-  const seen = new Map();
-  services.forEach(s =>
-    (s.serviceOwners || []).forEach(o => {
-      if (o && o.name) {
-        const key = o.name.toLowerCase();
-        if (!seen.has(key)) seen.set(key, o.name);
-      }
-    })
-  );
-  return Array.from(seen.values()).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+  const names     = services.flatMap(s => (s.serviceOwners || []).map(o => o?.name).filter(Boolean));
+  const uniqNames = new Map(names.map(n => [n.toLowerCase(), n]));
+  return Array.from(uniqNames.values()).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
 }
 
 function ServicesTable({ services, omitParentApp }) {


### PR DESCRIPTION
Added a dropdown to the Services page that allows users to filter services by service owners. 

Changes to `Services.js`:
- Added `collectServiceOwnerNames()` helper function for getting unique service owner names.
- Renamed original `Services` component to `ServicesTable`
- New `Services` component wraps `ServicesTable` with a PatternFly FormSelect dropdown for filtering 

Known limitation: Some teams have inconsistent `serviceOwner` names in app-interface (i.e. "appsre" vs. "App SRE" vs. "App SRE Team"). The dropdown displays these as-is. Tracked in APPSRE-14011

Issue: APPSRE-10853

Assisted by Claude

PS: First pull request here, please let me know if there is something I should change/can be done better.