### PR TITLE
Fix volumeMount to use subPath for ConfigMap

### DIFF
--- a/openshift/visual-qontract.yaml
+++ b/openshift/visual-qontract.yaml
@@ -86,7 +86,8 @@ objects:
               memory: ${MEMORY_LIMIT}
           volumeMounts:
             - name: visual-qontract-env
-              mountPath: /opt/visual-qontract/build/
+              mountPath: /opt/visual-qontract/build/env-config.js
+              subPath: env-config.js
               readOnly: true
         volumes:
         - name: visual-qontract-env
@@ -178,7 +179,8 @@ objects:
               memory: ${MEMORY_LIMIT}
           volumeMounts:
             - name: visual-qontract-env
-              mountPath: /opt/visual-qontract/build/
+              mountPath: /opt/visual-qontract/build/env-config.js
+              subPath: env-config.js
               readOnly: true
         volumes:
         - name: visual-qontract-env


### PR DESCRIPTION
## Fix

Add `subPath` to ConfigMap volumeMount to prevent overlaying the entire build directory.

**Before:**
```yaml
volumeMounts:
- name: visual-qontract-env
  mountPath: /opt/visual-qontract/build/  # Hides all React build files
  readOnly: true
```

**After:**
```yaml
volumeMounts:
- name: visual-qontract-env
  mountPath: /opt/visual-qontract/build/env-config.js
  subPath: env-config.js  # Preserves existing files
  readOnly: true
```

Without `subPath`, mounting the ConfigMap replaces the entire directory, causing 403 errors on readiness/liveness probes because index.html and other assets are hidden.

Fixes both main and canary deployments.