### PR TITLE
Add nginx proxy for GraphQL API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,9 @@ RUN npm run lint && npm test -- --coverage --ci --watchAll=false
 ### prod image
 FROM registry.access.redhat.com/ubi9/nginx-124@sha256:7acbb277f6922c47e55b5f65c39d7352e58de3dc6ecc2a7259011c88bf4d2249 AS prod
 
-# Copy nginx configuration
+# Copy nginx configuration and entrypoint
 COPY deployment/nginx.conf /etc/nginx/nginx.conf
+COPY deployment/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Copy built application
 COPY --from=base /opt/visual-qontract/build /opt/visual-qontract/build
@@ -29,6 +30,7 @@ COPY --from=base /opt/visual-qontract/build /opt/visual-qontract/build
 # Create necessary directories and fix permissions
 USER root
 RUN mkdir -p /var/cache/nginx /var/log/nginx /var/run && \
+    chmod +x /usr/local/bin/entrypoint.sh && \
     chown -R 1001:1001 /opt/visual-qontract/build \
     /var/cache/nginx \
     /var/log/nginx \
@@ -47,4 +49,6 @@ LABEL name="visual-qontract" \
 
 EXPOSE 8080
 USER 1001
-CMD ["nginx", "-g", "daemon off;"]
+
+# Use entrypoint script to template nginx config with environment variables
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/deployment/entrypoint.sh
+++ b/deployment/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Template nginx configuration with environment variables
+envsubst '${GRAPHQL_URI} ${AUTHORIZATION}' < /etc/nginx/nginx.conf > /tmp/nginx.conf
+mv /tmp/nginx.conf /etc/nginx/nginx.conf
+
+# Start nginx
+exec nginx -g "daemon off;"

--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -64,6 +64,16 @@ http {
             try_files $uri =404;
         }
 
+        # GraphQL API proxy
+        location /graphql {
+            proxy_pass ${GRAPHQL_URI};
+            proxy_set_header Authorization "${AUTHORIZATION}";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         # Main application - SPA routing
         location / {
             try_files $uri $uri/ /index.html;

--- a/openshift/visual-qontract.yaml
+++ b/openshift/visual-qontract.yaml
@@ -57,6 +57,11 @@ objects:
           imagePullPolicy: Always
           name: visual-qontract
           env:
+          - name: GRAPHQL_URI
+            valueFrom:
+              configMapKeyRef:
+                  key: graphql.uri
+                  name: visual-qontract
           - name: AUTHORIZATION
             valueFrom:
               secretKeyRef:
@@ -149,6 +154,11 @@ objects:
           imagePullPolicy: Always
           name: visual-qontract
           env:
+          - name: GRAPHQL_URI
+            valueFrom:
+              configMapKeyRef:
+                  key: graphql.uri
+                  name: visual-qontract
           - name: AUTHORIZATION
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
## Fix

Add nginx reverse proxy for GraphQL requests to eliminate CORS errors.

**Problem:** PatternFly 6 upgrade removed the nginx proxy that forwarded /graphql requests. The app now makes direct cross-origin requests to app-interface.*.devshift.net, causing CORS errors.

**Solution:** Restore nginx proxy using entrypoint script to template the backend URL.

### Changes

1. **Entrypoint script** (`deployment/entrypoint.sh`): Uses envsubst to inject GRAPHQL_URI and AUTHORIZATION into nginx.conf
2. **Nginx proxy** (`deployment/nginx.conf`): Added `location /graphql` to proxy requests  
3. **Dockerfile**: Copy entrypoint, make executable, use as ENTRYPOINT
4. **Deployment template**: Pass GRAPHQL_URI env var from ConfigMap

### How it works

1. ConfigMap provides `graphql.uri` key with backend URL
2. Deployment passes it as `GRAPHQL_URI` environment variable
3. Entrypoint templates nginx.conf with the backend URL and auth header
4. React app makes requests to `/graphql` (relative, same origin)
5. Nginx proxies to backend with authentication

No CORS headers needed - same origin requests.

### App-interface changes needed

ConfigMaps must be updated to:
- Add `graphql.uri` key (for nginx env var)
- Change `REACT_APP_GRAPHQL_ENDPOINT` from absolute URL to `/graphql`