### PR TITLE
Fix nginx config permission issue

### DIFF
--- a/deployment/entrypoint.sh
+++ b/deployment/entrypoint.sh
@@ -2,8 +2,8 @@
 set -e
 
 # Template nginx configuration with environment variables
-envsubst '${GRAPHQL_URI} ${AUTHORIZATION}' < /etc/nginx/nginx.conf > /tmp/nginx.conf
-mv /tmp/nginx.conf /etc/nginx/nginx.conf
+# Use /var/run for runtime files (owned by user 1001)
+envsubst '${GRAPHQL_URI} ${AUTHORIZATION}' < /etc/nginx/nginx.conf > /var/run/nginx.conf
 
-# Start nginx
-exec nginx -g "daemon off;"
+# Start nginx with custom config location
+exec nginx -c /var/run/nginx.conf -g "daemon off;"

--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -14,7 +14,7 @@ http {
     access_log /dev/stdout;
 
     # Basic configuration
-    include mime.types;
+    include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
     # Performance optimizations


### PR DESCRIPTION
Write templated nginx.conf to `/var/run` (already owned by user 1001) instead of trying to overwrite `/etc/nginx/nginx.conf`, avoiding permission denied errors when the container starts.

Fixes: `mv: cannot move '/tmp/nginx.conf' to '/etc/nginx/nginx.conf': Permission denied`