### PR TITLE
Fix nginx proxy Host header for /graphql endpoint

### DIFF
--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -41,6 +41,10 @@ http {
         application/atom+xml
         image/svg+xml;
 
+    # DNS resolver for upstream proxy
+    resolver 172.30.0.10 valid=10s;
+    resolver_timeout 5s;
+
     server {
         listen 8080 default_server;
         client_max_body_size 10m;
@@ -68,7 +72,6 @@ http {
         location /graphql {
             proxy_pass ${GRAPHQL_URI};
             proxy_set_header Authorization "${AUTHORIZATION}";
-            proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
Remove `proxy_set_header Host $host;` from the /graphql proxy location. When visual-qontract proxies to app-interface backend, sending the original Host header (visual-app-interface.stage.devshift.net) causes the OpenShift router to return 503 errors because it doesn't recognize that hostname.

Also adds DNS resolver directive to use OpenShift cluster DNS for upstream hostname resolution.

## Testing

Hot-patched the running stage pod and verified:
- `/graphql` requests now return HTTP 200 ✓
- GraphQL queries execute successfully ✓
- Backend receives requests with correct Host header ✓

Fixes 503 Service Unavailable errors on /graphql requests.