### PR TITLE
Fix URL encoding to restore human-readable URLs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -129,35 +129,35 @@ function App() {
                 <Routes>
                   <Route path="/" element={<Home />} />
                   <Route path="/services" element={<Services />} />
-                  <Route path="/service/:servicePath" element={<Service />} />
+                  <Route path="/service/*" element={<Service />} />
                   <Route path="/clusters" element={<Clusters />} />
-                  <Route path="/cluster/:path" element={<Cluster />} />
+                  <Route path="/cluster/*" element={<Cluster />} />
                   <Route path="/namespaces" element={<Namespaces />} />
-                  <Route path="/namespace/:namespacePath" element={<Namespace />} />
+                  <Route path="/namespace/*" element={<Namespace />} />
                   <Route path="/roles" element={<Roles />} />
-                  <Route path="/role/:path" element={<Role />} />
+                  <Route path="/role/*" element={<Role />} />
                   <Route path="/users" element={<Users />} />
-                  <Route path="/user/:path" element={<User />} />
+                  <Route path="/user/*" element={<User />} />
                   <Route path="/permissions" element={<Permissions />} />
-                  <Route path="/permission/:path" element={<Permission />} />
+                  <Route path="/permission/*" element={<Permission />} />
                   <Route path="/aws-accounts" element={<AWSAccounts />} />
-                  <Route path="/aws-account/:path" element={<AWSAccount />} />
+                  <Route path="/aws-account/*" element={<AWSAccount />} />
                   <Route path="/aws-groups" element={<AWSGroups />} />
-                  <Route path="/aws-group/:path" element={<AWSGroup />} />
+                  <Route path="/aws-group/*" element={<AWSGroup />} />
                   <Route path="/integrations" element={<Integrations />} />
-                  <Route path="/integration/:path" element={<Integration />} />
+                  <Route path="/integration/*" element={<Integration />} />
                   <Route path="/github-orgs" element={<GitHubOrgs />} />
-                  <Route path="/github-org/:path" element={<GitHubOrg />} />
+                  <Route path="/github-org/*" element={<GitHubOrg />} />
                   <Route path="/quay-orgs" element={<QuayOrgs />} />
-                  <Route path="/quay-org/:path" element={<QuayOrg />} />
+                  <Route path="/quay-org/*" element={<QuayOrg />} />
                   <Route path="/jenkins-instances" element={<JenkinsInstances />} />
-                  <Route path="/jenkins-instance/:path" element={<JenkinsInstance />} />
+                  <Route path="/jenkins-instance/*" element={<JenkinsInstance />} />
                   <Route path="/dependencies" element={<Dependencies />} />
-                  <Route path="/dependency/:path" element={<Dependency />} />
+                  <Route path="/dependency/*" element={<Dependency />} />
                   <Route path="/notifications" element={<Notifications />} />
-                  <Route path="/notification/:path" element={<Notification />} />
+                  <Route path="/notification/*" element={<Notification />} />
                   <Route path="/scorecards" element={<ScoreCards />} />
-                  <Route path="/scorecard/:path" element={<ScoreCard />} />
+                  <Route path="/scorecard/*" element={<ScoreCard />} />
                   <Route path="/status" element={<Status />} />
                 </Routes>
               </ErrorBoundary>

--- a/src/components/UsersTable.tsx
+++ b/src/components/UsersTable.tsx
@@ -53,7 +53,7 @@ const UsersTable: React.FC<UsersTableProps> = ({
             {showName && (
               <Td>
                 <Link
-                  to={`/user/${encodeURIComponent(user.path)}`}
+                  to={`/user${user.path}`}
                   style={{ textDecoration: 'none' }}
                 >
                   <Button

--- a/src/pages/AWSAccount.tsx
+++ b/src/pages/AWSAccount.tsx
@@ -43,8 +43,8 @@ interface AWSAccountData {
 }
 
 const AWSAccount: React.FC = () => {
-  const { path } = useParams<{ path: string }>();
-  const decodedPath = path ? decodeURIComponent(path) : '';
+  const { '*': path } = useParams<{ '*': string }>();
+  const decodedPath = path ? `/${path}` : '';
 
   const { loading, error, data } = useQuery<AWSAccountData>(GET_AWSACCOUNT, {
     variables: { path: decodedPath },

--- a/src/pages/AWSAccounts.tsx
+++ b/src/pages/AWSAccounts.tsx
@@ -134,7 +134,7 @@ const AWSAccounts: React.FC = () => {
               {paginatedAWSAccounts.map((account: AWSAccount) => (
                 <Tr key={account.path}>
                   <Td dataLabel="Name">
-                    <Link to={`/aws-account/${encodeURIComponent(account.path)}`} style={{ textDecoration: 'none' }}>
+                    <Link to={`/aws-account${account.path}`} style={{ textDecoration: 'none' }}>
                       <Button
                         variant="link"
                         style={{ padding: 0, fontSize: 'inherit', fontWeight: 'bold' }}

--- a/src/pages/AWSGroup.tsx
+++ b/src/pages/AWSGroup.tsx
@@ -55,9 +55,9 @@ interface AWSGroupData {
 }
 
 const AWSGroup: React.FC = () => {
-  const { path } = useParams<{ path: string }>();
+  const { '*': path } = useParams<{ '*': string }>();
   const { loading, error, data } = useQuery<AWSGroupData>(GET_AWSGROUP, {
-    variables: { path: decodeURIComponent(path || '') }
+    variables: { path: path ? `/${path}` : '' }
   });
 
   if (loading) {
@@ -152,7 +152,7 @@ const AWSGroup: React.FC = () => {
             <div style={{ display: 'grid', gap: '0.5rem' }}>
               <div>
                 <strong>Account Name:</strong>{' '}
-                <Link to={`/aws-account/${encodeURIComponent(group.account.path)}`} style={{ textDecoration: 'none' }}>
+                <Link to={`/aws-account${group.account.path}`} style={{ textDecoration: 'none' }}>
                   <Button
                     variant="link"
                     style={{ padding: 0, fontSize: 'inherit', fontWeight: 'bold' }}

--- a/src/pages/AWSGroups.tsx
+++ b/src/pages/AWSGroups.tsx
@@ -145,7 +145,7 @@ const AWSGroups: React.FC = () => {
               {paginatedAWSGroups.map((group: AWSGroup) => (
                 <Tr key={group.path}>
                   <Td dataLabel="Name">
-                    <Link to={`/aws-group/${encodeURIComponent(group.path)}`} style={{ textDecoration: 'none' }}>
+                    <Link to={`/aws-group${group.path}`} style={{ textDecoration: 'none' }}>
                       <Button
                         variant="link"
                         style={{ padding: 0, fontSize: 'inherit', fontWeight: 'bold' }}

--- a/src/pages/Cluster.tsx
+++ b/src/pages/Cluster.tsx
@@ -152,8 +152,8 @@ interface ClusterData {
 }
 
 const Cluster: React.FC = () => {
-  const { path } = useParams<{ path: string }>();
-  const decodedPath = path ? decodeURIComponent(path) : '';
+  const { '*': path } = useParams<{ '*': string }>();
+  const decodedPath = path ? `/${path}` : '';
 
   const { loading, error, data } = useQuery<ClusterData>(GET_CLUSTER, {
     variables: { path: decodedPath },
@@ -436,7 +436,7 @@ const Cluster: React.FC = () => {
                     <Tr key={index}>
                       <Td>
                         <Link
-                          to={`/namespace/${encodeURIComponent(namespace.path)}`}
+                          to={`/namespace${namespace.path}`}
                           style={{ textDecoration: 'none' }}
                         >
                           <Button
@@ -484,7 +484,7 @@ const Cluster: React.FC = () => {
                       <Tr key={index}>
                         <Td>
                           <Link
-                            to={`/role/${encodeURIComponent(role.path)}`}
+                            to={`/role${role.path}`}
                             style={{ textDecoration: 'none' }}
                           >
                             <Button

--- a/src/pages/Clusters.tsx
+++ b/src/pages/Clusters.tsx
@@ -283,7 +283,7 @@ const Clusters: React.FC = () => {
                   <Td>
                     <div>
                       <Link
-                        to={`/cluster/${encodeURIComponent(cluster.path)}`}
+                        to={`/cluster${cluster.path}`}
                         style={{ textDecoration: 'none' }}
                       >
                         <Button
@@ -385,7 +385,7 @@ const Clusters: React.FC = () => {
                               padding: '0.125rem 0'
                             }}>
                               <Link
-                                to={`/service/${encodeURIComponent(app.path)}`}
+                                to={`/service${app.path}`}
                                 style={{ textDecoration: 'none' }}
                               >
                                 <Button
@@ -470,7 +470,7 @@ const Clusters: React.FC = () => {
                       <Td>
                         <div>
                           <Link
-                            to={`/cluster/${encodeURIComponent(cluster.path)}`}
+                            to={`/cluster${cluster.path}`}
                             style={{ textDecoration: 'none' }}
                           >
                             <Button
@@ -558,7 +558,7 @@ const Clusters: React.FC = () => {
                                   padding: '0.125rem 0'
                                 }}>
                                   <Link
-                                    to={`/service/${encodeURIComponent(app.path)}`}
+                                    to={`/service${app.path}`}
                                     style={{ textDecoration: 'none' }}
                                   >
                                     <Button

--- a/src/pages/Dependencies.tsx
+++ b/src/pages/Dependencies.tsx
@@ -155,7 +155,7 @@ const Dependencies: React.FC = () => {
               {paginatedDependencies.map((dependency: Dependency) => (
                 <Tr key={dependency.path}>
                   <Td dataLabel="Name">
-                    <Link to={`/dependency/${encodeURIComponent(dependency.path)}`} style={{ textDecoration: 'none' }}>
+                    <Link to={`/dependency${dependency.path}`} style={{ textDecoration: 'none' }}>
                       <Button
                         variant="link"
                         style={{ padding: 0, fontSize: 'inherit', fontWeight: 'bold' }}

--- a/src/pages/Dependency.tsx
+++ b/src/pages/Dependency.tsx
@@ -55,9 +55,9 @@ interface DependencyData {
 }
 
 const Dependency: React.FC = () => {
-  const { path } = useParams<{ path: string }>();
+  const { '*': path } = useParams<{ '*': string }>();
   const { loading, error, data } = useQuery<DependencyData>(GET_DEPENDENCY, {
-    variables: { path: decodeURIComponent(path || '') }
+    variables: { path: path ? `/${path}` : '' }
   });
 
   if (loading) {

--- a/src/pages/GitHubOrg.tsx
+++ b/src/pages/GitHubOrg.tsx
@@ -45,9 +45,9 @@ interface GitHubOrgData {
 }
 
 const GitHubOrg: React.FC = () => {
-  const { path } = useParams<{ path: string }>();
+  const { '*': path } = useParams<{ '*': string }>();
   const { loading, error, data } = useQuery<GitHubOrgData>(GET_GITHUBORG, {
-    variables: { path: decodeURIComponent(path || '') }
+    variables: { path: path ? `/${path}` : '' }
   });
 
   if (loading) {

--- a/src/pages/GitHubOrgs.tsx
+++ b/src/pages/GitHubOrgs.tsx
@@ -134,7 +134,7 @@ const GitHubOrgs: React.FC = () => {
               {paginatedGitHubOrgs.map((org: GitHubOrg) => (
                 <Tr key={org.path}>
                   <Td dataLabel="Name">
-                    <Link to={`/github-org/${encodeURIComponent(org.path)}`} style={{ textDecoration: 'none' }}>
+                    <Link to={`/github-org${org.path}`} style={{ textDecoration: 'none' }}>
                       <Button
                         variant="link"
                         style={{ padding: 0, fontSize: 'inherit', fontWeight: 'bold' }}

--- a/src/pages/Integration.tsx
+++ b/src/pages/Integration.tsx
@@ -41,9 +41,9 @@ interface IntegrationData {
 }
 
 const Integration: React.FC = () => {
-  const { path } = useParams<{ path: string }>();
+  const { '*': path } = useParams<{ '*': string }>();
   const { loading, error, data } = useQuery<IntegrationData>(GET_INTEGRATION, {
-    variables: { path: decodeURIComponent(path || '') }
+    variables: { path: path ? `/${path}` : '' }
   });
 
   if (loading) {

--- a/src/pages/Integrations.tsx
+++ b/src/pages/Integrations.tsx
@@ -138,7 +138,7 @@ const Integrations: React.FC = () => {
               {paginatedIntegrations.map((integration: Integration) => (
                 <Tr key={integration.path}>
                   <Td dataLabel="Name">
-                    <Link to={`/integration/${encodeURIComponent(integration.path)}`} style={{ textDecoration: 'none' }}>
+                    <Link to={`/integration${integration.path}`} style={{ textDecoration: 'none' }}>
                       <Button
                         variant="link"
                         style={{ padding: 0, fontSize: 'inherit', fontWeight: 'bold' }}

--- a/src/pages/JenkinsInstance.tsx
+++ b/src/pages/JenkinsInstance.tsx
@@ -41,9 +41,9 @@ interface JenkinsInstanceData {
 }
 
 const JenkinsInstance: React.FC = () => {
-  const { path } = useParams<{ path: string }>();
+  const { '*': path } = useParams<{ '*': string }>();
   const { loading, error, data } = useQuery<JenkinsInstanceData>(GET_INSTANCE, {
-    variables: { path: decodeURIComponent(path || '') }
+    variables: { path: path ? `/${path}` : '' }
   });
 
   if (loading) {

--- a/src/pages/JenkinsInstances.tsx
+++ b/src/pages/JenkinsInstances.tsx
@@ -138,7 +138,7 @@ const JenkinsInstances: React.FC = () => {
               {paginatedJenkinsInstances.map((instance: JenkinsInstance) => (
                 <Tr key={instance.path}>
                   <Td dataLabel="Name">
-                    <Link to={`/jenkins-instance/${encodeURIComponent(instance.path)}`} style={{ textDecoration: 'none' }}>
+                    <Link to={`/jenkins-instance${instance.path}`} style={{ textDecoration: 'none' }}>
                       <Button
                         variant="link"
                         style={{ padding: 0, fontSize: 'inherit', fontWeight: 'bold' }}

--- a/src/pages/Namespace.tsx
+++ b/src/pages/Namespace.tsx
@@ -132,8 +132,8 @@ interface NamespaceData {
 }
 
 const Namespace: React.FC = () => {
-  const { namespacePath } = useParams<{ namespacePath: string }>();
-  const decodedPath = namespacePath ? decodeURIComponent(namespacePath) : '';
+  const { '*': path } = useParams<{ '*': string }>();
+  const decodedPath = path ? `/${path}` : '';
 
   const { loading, error, data } = useQuery<NamespaceData>(GET_NAMESPACE, {
     variables: { path: decodedPath },
@@ -265,7 +265,7 @@ const Namespace: React.FC = () => {
                   <DescriptionListTerm>Application</DescriptionListTerm>
                   <DescriptionListDescription>
                     <Link
-                      to={`/service/${encodeURIComponent(namespace.app.path)}`}
+                      to={`/service${namespace.app.path}`}
                       style={{ textDecoration: 'none' }}
                     >
                       <Button

--- a/src/pages/Namespaces.tsx
+++ b/src/pages/Namespaces.tsx
@@ -157,7 +157,7 @@ const Namespaces: React.FC = () => {
                 <Tr key={namespace.path}>
                   <Td dataLabel="Namespace Name">
                     <Link
-                      to={`/namespace/${encodeURIComponent(namespace.path)}`}
+                      to={`/namespace${namespace.path}`}
                       style={{ textDecoration: 'none' }}
                     >
                       <Button
@@ -184,7 +184,7 @@ const Namespaces: React.FC = () => {
                   </Td>
                   <Td dataLabel="App">
                     <Link
-                      to={`/service/${encodeURIComponent(namespace.app.path)}`}
+                      to={`/service${namespace.app.path}`}
                       style={{ textDecoration: 'none' }}
                     >
                       <Button

--- a/src/pages/Notification.tsx
+++ b/src/pages/Notification.tsx
@@ -62,9 +62,9 @@ interface NotificationData {
 }
 
 const Notification: React.FC = () => {
-  const { path } = useParams<{ path: string }>();
+  const { '*': path } = useParams<{ '*': string }>();
   const { loading, error, data } = useQuery<NotificationData>(GET_NOTIFICATION, {
-    variables: { path: decodeURIComponent(path || '') }
+    variables: { path: path ? `/${path}` : '' }
   });
 
   if (loading) {
@@ -169,7 +169,7 @@ const Notification: React.FC = () => {
               <List>
                 {notification.to.users.map((user) => (
                   <ListItem key={user.path}>
-                    <Link to={`/user/${encodeURIComponent(user.path)}`} style={{ textDecoration: 'none' }}>
+                    <Link to={`/user${user.path}`} style={{ textDecoration: 'none' }}>
                       <Button
                         variant="link"
                         style={{ padding: 0, fontSize: 'inherit', fontWeight: 'bold' }}

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -169,7 +169,7 @@ const Notifications: React.FC = () => {
               {paginatedNotifications.map((notification: Notification) => (
                 <Tr key={notification.path}>
                   <Td dataLabel="Name">
-                    <Link to={`/notification/${encodeURIComponent(notification.path)}`} style={{ textDecoration: 'none' }}>
+                    <Link to={`/notification${notification.path}`} style={{ textDecoration: 'none' }}>
                       <Button
                         variant="link"
                         style={{ padding: 0, fontSize: 'inherit', fontWeight: 'bold' }}

--- a/src/pages/Permission.tsx
+++ b/src/pages/Permission.tsx
@@ -73,8 +73,8 @@ interface PermissionData {
 }
 
 const Permission: React.FC = () => {
-  const { path } = useParams<{ path: string }>();
-  const decodedPath = path ? decodeURIComponent(path) : '';
+  const { '*': path } = useParams<{ '*': string }>();
+  const decodedPath = path ? `/${path}` : '';
 
   const { loading, error, data } = useQuery<PermissionData>(GET_PERMISSION, {
     variables: { path: decodedPath },
@@ -202,7 +202,7 @@ const Permission: React.FC = () => {
                     <Tr key={index}>
                       <Td>
                         <Link
-                          to={`/role/${encodeURIComponent(role.path)}`}
+                          to={`/role${role.path}`}
                           style={{ textDecoration: 'none' }}
                         >
                           <Button

--- a/src/pages/Permissions.tsx
+++ b/src/pages/Permissions.tsx
@@ -139,7 +139,7 @@ const Permissions: React.FC = () => {
                 <Tr key={permission.path}>
                   <Td dataLabel="Name">
                     <Link
-                      to={`/permission/${encodeURIComponent(permission.path)}`}
+                      to={`/permission${permission.path}`}
                       style={{ textDecoration: 'none' }}
                     >
                       <Button

--- a/src/pages/QuayOrg.tsx
+++ b/src/pages/QuayOrg.tsx
@@ -43,9 +43,9 @@ interface QuayOrgData {
 }
 
 const QuayOrg: React.FC = () => {
-  const { path } = useParams<{ path: string }>();
+  const { '*': path } = useParams<{ '*': string }>();
   const { loading, error, data } = useQuery<QuayOrgData>(GET_QUAYORG, {
-    variables: { path: decodeURIComponent(path || '') }
+    variables: { path: path ? `/${path}` : '' }
   });
 
   if (loading) {

--- a/src/pages/QuayOrgs.tsx
+++ b/src/pages/QuayOrgs.tsx
@@ -134,7 +134,7 @@ const QuayOrgs: React.FC = () => {
               {paginatedQuayOrgs.map((org: QuayOrg) => (
                 <Tr key={org.path}>
                   <Td dataLabel="Name">
-                    <Link to={`/quay-org/${encodeURIComponent(org.path)}`} style={{ textDecoration: 'none' }}>
+                    <Link to={`/quay-org${org.path}`} style={{ textDecoration: 'none' }}>
                       <Button
                         variant="link"
                         style={{ padding: 0, fontSize: 'inherit', fontWeight: 'bold' }}

--- a/src/pages/Role.tsx
+++ b/src/pages/Role.tsx
@@ -116,8 +116,8 @@ interface RoleData {
 }
 
 const Role: React.FC = () => {
-  const { path } = useParams<{ path: string }>();
-  const decodedPath = path ? decodeURIComponent(path) : '';
+  const { '*': path } = useParams<{ '*': string }>();
+  const decodedPath = path ? `/${path}` : '';
 
   const { loading, error, data } = useQuery<RoleData>(GET_ROLE, {
     variables: { path: decodedPath },
@@ -276,7 +276,7 @@ const Role: React.FC = () => {
                     <Tr key={index}>
                       <Td>
                         <Link
-                          to={`/namespace/${encodeURIComponent(access.namespace!.path)}`}
+                          to={`/namespace${access.namespace!.path}`}
                           style={{ textDecoration: 'none' }}
                         >
                           <Button
@@ -289,7 +289,7 @@ const Role: React.FC = () => {
                       </Td>
                       <Td>
                         <Link
-                          to={`/cluster/${encodeURIComponent(access.namespace!.cluster.path)}`}
+                          to={`/cluster${access.namespace!.cluster.path}`}
                           style={{ textDecoration: 'none' }}
                         >
                           <Button
@@ -326,7 +326,7 @@ const Role: React.FC = () => {
                     <Tr key={index}>
                       <Td>
                         <Link
-                          to={`/cluster/${encodeURIComponent(access.cluster!.path)}`}
+                          to={`/cluster${access.cluster!.path}`}
                           style={{ textDecoration: 'none' }}
                         >
                           <Button

--- a/src/pages/Roles.tsx
+++ b/src/pages/Roles.tsx
@@ -135,7 +135,7 @@ const Roles: React.FC = () => {
                 <Tr key={role.path}>
                   <Td dataLabel="Name">
                     <Link
-                      to={`/role/${encodeURIComponent(role.path)}`}
+                      to={`/role${role.path}`}
                       style={{ textDecoration: 'none' }}
                     >
                       <Button

--- a/src/pages/ScoreCard.tsx
+++ b/src/pages/ScoreCard.tsx
@@ -62,9 +62,9 @@ interface ScoreCardData {
 }
 
 const ScoreCard: React.FC = () => {
-  const { path } = useParams<{ path: string }>();
+  const { '*': path } = useParams<{ '*': string }>();
   const { loading, error, data } = useQuery<ScoreCardData>(GET_SCORECARD, {
-    variables: { path: decodeURIComponent(path || '') }
+    variables: { path: path ? `/${path}` : '' }
   });
 
   const getStatusIcon = (status: string) => {

--- a/src/pages/ScoreCards.tsx
+++ b/src/pages/ScoreCards.tsx
@@ -140,7 +140,7 @@ const ScoreCards: React.FC = () => {
               {paginatedScoreCards.map((scorecard: ScoreCard) => (
                 <Tr key={scorecard.path}>
                   <Td dataLabel="App Name">
-                    <Link to={`/scorecard/${encodeURIComponent(scorecard.path)}`} style={{ textDecoration: 'none' }}>
+                    <Link to={`/scorecard${scorecard.path}`} style={{ textDecoration: 'none' }}>
                       <Button
                         variant="link"
                         style={{ padding: 0, fontSize: 'inherit', fontWeight: 'bold' }}

--- a/src/pages/Service.tsx
+++ b/src/pages/Service.tsx
@@ -346,8 +346,8 @@ interface ServiceData {
 }
 
 const Service: React.FC = () => {
-  const { servicePath } = useParams<{ servicePath: string }>();
-  const decodedPath = servicePath ? decodeURIComponent(servicePath) : '';
+  const { '*': path } = useParams<{ '*': string }>();
+  const decodedPath = path ? `/${path}` : '';
   const [namespaceSearchTerm, setNamespaceSearchTerm] = useState('');
 
   const { loading, error, data } = useQuery<ServiceData>(GET_SERVICE, {
@@ -822,7 +822,7 @@ const Service: React.FC = () => {
                       <Tr key={index}>
                         <Td>
                           <Link
-                            to={`/namespace/${encodeURIComponent(namespace.path)}`}
+                            to={`/namespace${namespace.path}`}
                             style={{ textDecoration: 'none' }}
                           >
                             <Button
@@ -912,7 +912,7 @@ const Service: React.FC = () => {
                       <Tr key={index}>
                         <Td>
                           <Link
-                            to={`/service/${encodeURIComponent(child.path)}`}
+                            to={`/service${child.path}`}
                             style={{ textDecoration: 'none' }}
                           >
                             <Button

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -221,7 +221,7 @@ const Services: React.FC = () => {
                 <Tr key={service.path}>
                   <Td dataLabel="Service Name">
                     <Link 
-                      to={`/service/${encodeURIComponent(service.path)}`}
+                      to={`/service${service.path}`}
                       style={{ textDecoration: 'none' }}
                     >
                       <Button
@@ -240,7 +240,7 @@ const Services: React.FC = () => {
                   <Td dataLabel="Parent App">
                     {service.parentApp ? (
                       <Link
-                        to={`/service/${encodeURIComponent(service.parentApp.path)}`}
+                        to={`/service${service.parentApp.path}`}
                         style={{ textDecoration: 'none' }}
                       >
                         <Button

--- a/src/pages/User.tsx
+++ b/src/pages/User.tsx
@@ -63,8 +63,8 @@ interface UserData {
 }
 
 const User: React.FC = () => {
-  const { path } = useParams<{ path: string }>();
-  const decodedPath = path ? decodeURIComponent(path) : '';
+  const { '*': path } = useParams<{ '*': string }>();
+  const decodedPath = path ? `/${path}` : '';
 
   const { loading, error, data } = useQuery<UserData>(GET_USER, {
     variables: { path: decodedPath },
@@ -251,7 +251,7 @@ const User: React.FC = () => {
                     <Tr key={index}>
                       <Td>
                         <Link
-                          to={`/role/${encodeURIComponent(role.path)}`}
+                          to={`/role${role.path}`}
                           style={{ textDecoration: 'none' }}
                         >
                           <Button


### PR DESCRIPTION
Changed from parameterized routes to wildcard routes to support paths with slashes without URL encoding.

**Before**: `/cluster/%2Fopenshift%2Fapp-sre-prod-04%2Fcluster.yml`  
**After**: `/cluster/openshift/app-sre-prod-04/cluster.yml`

## Changes
- Updated route definitions in App.tsx to use wildcard pattern (`/*`)
- Updated all page components to extract wildcard parameters
- Removed `encodeURIComponent()` from all link generation
- Added leading slash to captured paths for GraphQL queries

Backward compatible with existing bookmarks.