### PR TITLE
fix(service): restore SaaS files filtering by service name

### DIFF
--- a/src/pages/Service.tsx
+++ b/src/pages/Service.tsx
@@ -384,6 +384,14 @@ const Service: React.FC = () => {
     );
   }, [service?.namespaces, namespaceSearchTerm]);
 
+  const filteredSaasFiles = useMemo(() => {
+    if (!data?.saas_files_v2 || !service) return [];
+
+    return data.saas_files_v2.filter((saasFile) =>
+      saasFile.app.name === service.name
+    );
+  }, [data?.saas_files_v2, service]);
+
   if (loading) {
     return <LoadingState message="Loading service details..." />;
   }
@@ -642,7 +650,7 @@ const Service: React.FC = () => {
         )}
 
         {/* SaaS Files */}
-        {data?.saas_files_v2 && (
+        {filteredSaasFiles.length > 0 && (
           <GridItem span={12}>
             <Card>
               <CardTitle>SaaS Files</CardTitle>
@@ -655,14 +663,14 @@ const Service: React.FC = () => {
                     </Tr>
                   </Thead>
                   <Tbody>
-                    {data?.saas_files_v2?.length === 0 ? (
+                    {filteredSaasFiles.length === 0 ? (
                       <Tr>
                         <Td colSpan={2} style={{ textAlign: 'center', padding: '2rem' }}>
                           No SaaS files found for this service
                         </Td>
                       </Tr>
                     ) : (
-                      data?.saas_files_v2?.map((saasFile, index) => {
+                      filteredSaasFiles.map((saasFile, index) => {
                       const pp_cluster_console_url = saasFile.pipelinesProvider?.namespace?.cluster?.consoleUrl;
                       const pp_ns_name = saasFile.pipelinesProvider?.namespace?.name;
 


### PR DESCRIPTION
## Summary

Fixes a bug introduced during the PatternFly v6 migration where SaaS files were not being filtered by service name on the Service detail page.

## Problem

After the PatternFly v6 upgrade, the Service page was displaying **all** SaaS files from the entire database instead of only showing SaaS files belonging to the current service. This happened because the client-side filtering logic was lost during the migration from `Service.js` to `Service.tsx`.

## Solution

Restored the filtering behavior by:
- Adding a `filteredSaasFiles` useMemo hook that filters `saas_files_v2` where `saasFile.app.name === service.name`
- Updated the SaaS Files section to use `filteredSaasFiles` instead of the raw GraphQL query result

This matches the original pre-upgrade behavior and follows the same pattern used for namespace filtering in the same component.

## Technical Notes

Client-side filtering is necessary because the qontract-server GraphQL implementation doesn't support filtering `saas_files_v2` by relationship fields like `app`. The query only supports filtering by scalar fields marked as `isSearchable` (currently just `name`).

## Testing

- ✅ Build succeeds with no TypeScript errors
- ✅ Filtering logic matches original implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)